### PR TITLE
changing unit handling to central pint unit registry

### DIFF
--- a/src/modacor/dataclasses/validators.py
+++ b/src/modacor/dataclasses/validators.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from numbers import Integral
 from typing import Any, Type
 
-import pint
+from modacor import ureg
 
 from .databundle import DataBundle
 from .messagehandler import MessageHandler
@@ -31,7 +31,7 @@ def is_list_of_ints(instance: Type, attribute: str, value: Any):
 def check_data(
     data: DataBundle,
     data_element_name: str = None,
-    required_unit: pint.Unit = None,
+    required_unit: ureg.Unit = None,
     message_handler: MessageHandler = _dummy_handler,
 ) -> bool:
     """
@@ -52,7 +52,7 @@ def check_data(
 def check_data_element_and_units(
     data: DataBundle,
     data_element_name: str,
-    required_unit: pint.Unit,
+    required_unit: ureg.Unit,
     message_handler: MessageHandler,
 ) -> bool:
     """

--- a/src/modacor/tests/test_basedata.py
+++ b/src/modacor/tests/test_basedata.py
@@ -2,6 +2,8 @@ import numpy as np
 import pint
 import pytest
 
+from modacor import ureg
+
 # import tiled.client  # not sure what the class of tiled.client is...
 from ..dataclasses.basedata import BaseData  # adjust the import path as needed
 
@@ -12,16 +14,11 @@ class DummyClient:
 
 
 @pytest.fixture
-def ureg():
-    return pint.UnitRegistry()
-
-
-@pytest.fixture
 def sample_data():
     return np.arange(5)
 
 
-def test_data_and_display_data_properties(ureg, sample_data):
+def test_data_and_display_data_properties(sample_data):
     # Create an instance of BaseData with test values
     bd = BaseData(
         ingest_units=ureg.m,  # meters
@@ -51,7 +48,7 @@ def test_data_and_display_data_properties(ureg, sample_data):
     ).all(), "display_data property did not convert units correctly."
 
 
-def test_rank_validation_exceeds_ndim(ureg):
+def test_rank_validation_exceeds_ndim():
     # Create a 2D DataArray
     arr = np.arange(4).reshape((2, 2))
 


### PR DESCRIPTION
making sure we can define new units in a central location, and following pint practices, we now use a central unit registry: 
from modacor import ureg