### PR TITLE
Adding the option to the pipeline tracer to store processing data in all steps. 

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -21,4 +21,4 @@ repo_main_branch: main
 repo_name: MoDaCor
 repo_userorg: BAMresearch
 sphinx_theme: pydata-sphinx-theme
-version: 1.3.1
+version: 1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v1.3.2 (2026-05-07)
+
+### Bug fixes
+
+* fix: fixing the documentation for clarity ([`c940aca`](https://github.com/BAMresearch/MoDaCor/commit/c940acacdc82a531756a1a2e42b0acf257645a8a))
+
+### Unknown Scope
+
+* adding the option to add processingData snapshots to the trace ([`5635e33`](https://github.com/BAMresearch/MoDaCor/commit/5635e337a3d2a0c34668784c23e2d2c79ef9d18d))
+
 ## v1.3.1 (2026-05-07)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoDaCor (v1.3.1)
+# MoDaCor (v1.3.2)
 
 ## Overview
 
@@ -6,7 +6,7 @@ New modular data corrections for any neutron or X-ray technique that produces 1D
 data.
 
 [![PyPI Package latest release](https://img.shields.io/pypi/v/modacor.svg)](https://pypi.org/project/modacor)
-[![Commits since latest release](https://img.shields.io/github/commits-since/BAMresearch/MoDaCor/v1.3.1.svg)](https://github.com/BAMresearch/MoDaCor/compare/v1.3.1...main)
+[![Commits since latest release](https://img.shields.io/github/commits-since/BAMresearch/MoDaCor/v1.3.2.svg)](https://github.com/BAMresearch/MoDaCor/compare/v1.3.2...main)
 [![License](https://img.shields.io/pypi/l/modacor.svg)](https://en.wikipedia.org/wiki/BSD-3-Clause)
 [![Supported versions](https://img.shields.io/pypi/pyversions/modacor.svg)](https://pypi.org/project/modacor)
 [![PyPI Wheel](https://img.shields.io/pypi/wheel/modacor.svg)](https://pypi.org/project/modacor#files)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ author = (
     "Brian R. Pauw, Malte Storm, Jérôme Kieffer, Ingo Breßler, Anja Hörmann, Glen Smales, Armin Moser, and Tim Snow"
 )
 copyright = "{0}, {1}".format(year, author)
-version = "1.3.1"
+version = "1.3.2"
 release = version
 commit_id = None
 try:

--- a/docs/pipeline_operations/runtime_service_api.md
+++ b/docs/pipeline_operations/runtime_service_api.md
@@ -183,7 +183,9 @@ Request:
   "trace": {
     "enabled": true,
     "watch": {"sample": ["signal"]},
-    "record_only_on_change": true
+    "record_only_on_change": true,
+    "snapshot_processing_data": false,
+    "snapshot_step_ids": []
   },
   "auto_full_reset_on_partial_error": true
 }
@@ -398,6 +400,9 @@ Notes:
 - `changed_sources` or `changed_keys` is required for `partial`; both are optional for `auto`.
 - `changed_keys` enables key-aware invalidation (e.g. `sample.signal`, `sample.Q`) for tighter partial reruns.
 - `write_hdf` is optional; if provided, pipeline spec/yaml and trace are persisted.
+- Full per-step `ProcessingData` snapshots are opt-in through the session trace
+  config. When enabled, the HDF export stores them under
+  `/processing/tracer/<run>/steps/<step>/processing_data`.
 
 ### `POST /sessions/{session_id}/process/dry-run`
 
@@ -611,7 +616,9 @@ curl -X POST "http://127.0.0.1:8000/v1/sessions" \
     "trace": {
       "enabled": true,
       "watch": {"sample": ["signal"], "background": ["signal"]},
-      "record_only_on_change": true
+      "record_only_on_change": true,
+      "snapshot_processing_data": false,
+      "snapshot_step_ids": []
     },
     "auto_full_reset_on_partial_error": true
   }'

--- a/docs/pipeline_operations/runtime_service_openapi.yaml
+++ b/docs/pipeline_operations/runtime_service_openapi.yaml
@@ -615,6 +615,15 @@ components:
         record_only_on_change:
           type: boolean
           default: true
+        snapshot_processing_data:
+          type: boolean
+          default: false
+          description: Capture full ProcessingData snapshots after traced steps for HDF export.
+        snapshot_step_ids:
+          type: array
+          description: Optional step ids to snapshot. Empty means every executed step when snapshot_processing_data is true.
+          items:
+            type: string
 
     CreateSessionRequest:
       type: object

--- a/docs/pipeline_operations/tracing_and_debugging.md
+++ b/docs/pipeline_operations/tracing_and_debugging.md
@@ -1,3 +1,30 @@
 # Tracing and debugging
 
-> **Note:** Placeholder section for future guidance on using `PipelineTracer`, trace exports, and performance diagnostics.
+`PipelineTracer` records lightweight per-step dataset probes by default:
+shape, units, dimensionality, rank, NaN counts, and optional min/max values.
+These probes are serialized into the HDF trace tree under
+`/processing/tracer/<run>/steps/<step>/datasets`.
+
+Full `ProcessingData` snapshots are separate and opt-in because they can be
+large. Enable them only for debugging runs where the intermediate arrays matter:
+
+```bash
+modacor run \
+  --pipeline pipeline.yaml \
+  --trace \
+  --trace-watch sample:signal,Q \
+  --trace-snapshot-processing-data \
+  --trace-snapshot-step S00617 \
+  --write-hdf debug.h5 \
+  --write-all-processing-data
+```
+
+If no `--trace-snapshot-step` is supplied, MoDaCor captures a snapshot after
+every executed step. HDF exports store snapshots at:
+
+```text
+/processing/tracer/<run>/steps/<step>/processing_data
+```
+
+The final result remains under `/processing/result/<run>`, and the file-level
+NeXus `default` chain points there rather than to an intermediate snapshot.

--- a/docs/pipeline_operations/tracing_and_debugging.md
+++ b/docs/pipeline_operations/tracing_and_debugging.md
@@ -14,7 +14,7 @@ modacor run \
   --trace \
   --trace-watch sample:signal,Q \
   --trace-snapshot-processing-data \
-  --trace-snapshot-step S00617 \
+  --trace-snapshot-step DC_bg \
   --write-hdf debug.h5 \
   --write-all-processing-data
 ```

--- a/src/modacor/__init__.py
+++ b/src/modacor/__init__.py
@@ -10,7 +10,7 @@ __copyright__ = "Copyright 2025, The MoDaCor team"
 __date__ = "22/11/2025"
 __status__ = "Development"  # "Development", "Production"
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 from pint import UnitRegistry, set_application_registry
 

--- a/src/modacor/cli.py
+++ b/src/modacor/cli.py
@@ -113,6 +113,18 @@ def _add_run_parser(subparsers: argparse._SubParsersAction[argparse.ArgumentPars
         help="Tracer watch spec (repeatable), for example 'sample:signal,Q'.",
     )
     run_parser.add_argument(
+        "--trace-snapshot-processing-data",
+        action="store_true",
+        help="Capture full ProcessingData snapshots after traced steps for HDF output.",
+    )
+    run_parser.add_argument(
+        "--trace-snapshot-step",
+        action="append",
+        default=[],
+        metavar="STEP_ID",
+        help="Limit ProcessingData trace snapshots to this step id (repeatable).",
+    )
+    run_parser.add_argument(
         "--stop-after",
         default=None,
         metavar="STEP_ID",
@@ -186,6 +198,18 @@ def _add_session_parser(subparsers: argparse._SubParsersAction[argparse.Argument
         default=[],
         metavar="BUNDLE:KEY[,KEY...]",
         help="Tracer watch spec (repeatable).",
+    )
+    create_parser.add_argument(
+        "--trace-snapshot-processing-data",
+        action="store_true",
+        help="Capture full ProcessingData snapshots after traced steps for HDF output.",
+    )
+    create_parser.add_argument(
+        "--trace-snapshot-step",
+        action="append",
+        default=[],
+        metavar="STEP_ID",
+        help="Limit ProcessingData trace snapshots to this step id (repeatable).",
     )
     create_parser.add_argument(
         "--no-auto-full-reset-on-partial-error",
@@ -276,13 +300,18 @@ def _run_command(args: argparse.Namespace) -> int:
     trace_watch = _parse_trace_watch(args.trace_watch)
     sources = _build_sources(hdf_sources=args.hdf_source, yaml_sources=args.yaml_source)
     sinks = _build_sinks(csv_sinks=args.csv_sink)
+    snapshot_processing_data = bool(args.trace_snapshot_processing_data or args.trace_snapshot_step)
 
     result = run_pipeline_job(
         args.pipeline,
         sources=sources,
         sinks=sinks,
-        trace=args.trace,
+        trace=bool(args.trace or snapshot_processing_data),
         trace_watch=trace_watch,
+        tracer_kwargs={
+            "snapshot_processing_data": snapshot_processing_data,
+            "snapshot_step_ids": set(args.trace_snapshot_step),
+        },
         stop_after=args.stop_after,
     )
 
@@ -338,14 +367,17 @@ def _session_create(base_url: str, args: argparse.Namespace) -> int:
     else:
         pipeline_payload = {"yaml_text": str(args.pipeline_yaml_text)}
 
+    snapshot_processing_data = bool(args.trace_snapshot_processing_data or args.trace_snapshot_step)
     payload = {
         "session_id": args.session_id,
         "name": args.name,
         "pipeline": pipeline_payload,
         "trace": {
-            "enabled": bool(args.trace),
+            "enabled": bool(args.trace or snapshot_processing_data),
             "watch": _parse_trace_watch(args.trace_watch),
             "record_only_on_change": True,
+            "snapshot_processing_data": snapshot_processing_data,
+            "snapshot_step_ids": list(args.trace_snapshot_step),
         },
         "auto_full_reset_on_partial_error": not bool(args.no_auto_full_reset_on_partial_error),
     }

--- a/src/modacor/debug/pipeline_tracer.py
+++ b/src/modacor/debug/pipeline_tracer.py
@@ -11,6 +11,7 @@ __date__ = "13/12/2025"
 __status__ = "Development"  # "Development", "Production"
 __version__ = "20251213.2"
 
+from copy import deepcopy
 from typing import Any, Protocol
 
 import numpy as np
@@ -43,26 +44,19 @@ ANSI = {
 
 
 class ReportRenderer(Protocol):
-    def header(self, text: str) -> str:
-        ...
+    def header(self, text: str) -> str: ...  # noqa: E704
 
-    def dim(self, text: str) -> str:
-        ...
+    def dim(self, text: str) -> str: ...  # noqa: E704
 
-    def ok(self, text: str) -> str:
-        ...
+    def ok(self, text: str) -> str: ...  # noqa: E704
 
-    def changed(self, text: str) -> str:
-        ...
+    def changed(self, text: str) -> str: ...  # noqa: E704
 
-    def badge_ok(self) -> str:
-        ...
+    def badge_ok(self) -> str: ...  # noqa: E704
 
-    def badge_changed(self) -> str:
-        ...
+    def badge_changed(self) -> str: ...  # noqa: E704
 
-    def codewrap(self, text: str) -> str:
-        ...
+    def codewrap(self, text: str) -> str: ...  # noqa: E704
 
 
 @define(frozen=True)
@@ -260,6 +254,11 @@ class PipelineTracer:
     # Include scalar min/max in probes (does not affect change detection unless you add "minmax" to change_kinds)
     compute_min_max: bool = False
 
+    # Optional full ProcessingData snapshots. These are intentionally kept out of
+    # `events` because events must remain lightweight and JSON-friendly.
+    snapshot_processing_data: bool = False
+    snapshot_step_ids: set[str] = field(factory=set)
+
     # Guards (fail fast at the *first* step that introduces the issue)
     fail_on_expected_mismatch: bool = False
     fail_on_nan_increase: bool = False
@@ -276,6 +275,7 @@ class PipelineTracer:
 
     _last: dict[tuple[str, str], BaseDataProbe] = field(factory=dict)
     events: list[dict[str, Any]] = field(factory=list)
+    processing_data_snapshots: list[dict[str, Any]] = field(factory=list)
 
     def _diff_kinds(self, prev: BaseDataProbe, now: BaseDataProbe) -> set[str]:
         kinds: set[str] = set()
@@ -409,6 +409,18 @@ class PipelineTracer:
 
                 if diff:
                     changed[(bundle_key, ds_key)] = {"prev": prev, "now": now, "diff": diff}
+
+        snapshot_step_ids = {str(value) for value in self.snapshot_step_ids}
+        if self.snapshot_processing_data and (not snapshot_step_ids or str(step_id) in snapshot_step_ids):
+            self.processing_data_snapshots.append(
+                {
+                    "step_id": str(step_id),
+                    "module": module,
+                    "name": name,
+                    "duration_s": duration_s,
+                    "processing_data": deepcopy(data),
+                }
+            )
 
         if (not self.record_only_on_change) or changed or self.record_empty_step_events:
             self.events.append(

--- a/src/modacor/io/hdf/hdf_processing_sink.py
+++ b/src/modacor/io/hdf/hdf_processing_sink.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import h5py
+import numpy as np
 from attrs import define, field, validators
 
 from modacor.dataclasses.basedata import BaseData
@@ -41,7 +42,63 @@ def _recreate_group(parent: h5py.Group | h5py.File, name: str) -> h5py.Group:
     return parent.create_group(name)
 
 
-def _write_basedata(group: h5py.Group, basedata: BaseData, *, compression: str | None = None) -> None:
+def _as_hdf_str_list(values: Sequence[str]) -> np.ndarray:
+    return np.asarray([str(value) for value in values], dtype=h5py.string_dtype(encoding="utf-8"))
+
+
+def _find_basedata_name(databundle: Any, axis: BaseData | None) -> str | None:
+    if axis is None:
+        return None
+    for name, candidate in databundle.items():
+        if candidate is axis:
+            return str(name)
+    return None
+
+
+def _infer_axis_names(databundle: Any, basedata: BaseData) -> list[str]:
+    ndim = int(np.asarray(basedata.signal).ndim)
+    if ndim == 0:
+        return []
+
+    axis_names: list[str] = []
+    if basedata.axes:
+        for idx, axis in enumerate(basedata.axes[:ndim]):
+            axis_names.append(_find_basedata_name(databundle, axis) or f"axis_{idx}")
+
+    if not axis_names and "Q" in databundle and isinstance(databundle["Q"], BaseData):
+        axis_names = ["Q"] * ndim
+
+    if len(axis_names) < ndim:
+        axis_names.extend(["."] * (ndim - len(axis_names)))
+    return axis_names[:ndim]
+
+
+def _q_indices_for_axes(axis_names: Sequence[str]) -> np.ndarray:
+    q_indices = [
+        idx
+        for idx, name in enumerate(axis_names)
+        if str(name).casefold() in {"q", "qx", "qy", "qz"} or str(name).casefold().startswith("q_")
+    ]
+    return np.asarray(q_indices, dtype=np.int64)
+
+
+def _is_default_plot(databundle: Any, basedata_name: str) -> bool:
+    default_plot = getattr(databundle, "default_plot", None)
+    if default_plot:
+        return str(default_plot) == basedata_name
+    return basedata_name == "signal"
+
+
+def _write_basedata(
+    group: h5py.Group,
+    basedata: BaseData,
+    *,
+    databundle: Any | None = None,
+    basedata_name: str | None = None,
+    compression: str | None = None,
+) -> None:
+    group.attrs["default"] = "signal"
+
     signal_dataset = group.create_dataset(
         "signal",
         data=basedata.signal,
@@ -49,6 +106,15 @@ def _write_basedata(group: h5py.Group, basedata: BaseData, *, compression: str |
     )
     signal_dataset.attrs["units"] = str(basedata.units)
     signal_dataset.attrs["rank_of_data"] = int(basedata.rank_of_data)
+
+    if databundle is not None and basedata_name is not None and _is_default_plot(databundle, basedata_name):
+        axis_names = _infer_axis_names(databundle, basedata)
+        group.attrs["NX_class"] = "NXdata"
+        group.attrs["canSAS_class"] = "SASdata"
+        group.attrs["signal"] = "signal"
+        group.attrs["axes"] = _as_hdf_str_list(axis_names)
+        group.attrs["I_axes"] = _as_hdf_str_list(axis_names)
+        group.attrs["Q_indices"] = _q_indices_for_axes(axis_names)
 
     # Weights: store only if non-scalar or not equal to 1.0
     weights_array = basedata.weights
@@ -110,6 +176,23 @@ def _normalise_trace_events(trace_events: Any | None) -> list[dict[str, Any]]:
                 normalised.append(event_dict)
         return normalised
     return []
+
+
+def _normalise_processing_data_snapshots(snapshots: Any | None) -> list[dict[str, Any]]:
+    if snapshots is None:
+        return []
+    if not isinstance(snapshots, list):
+        return []
+
+    normalised: list[dict[str, Any]] = []
+    for snapshot in snapshots:
+        if not isinstance(snapshot, dict):
+            continue
+        processing_data = snapshot.get("processing_data")
+        if not isinstance(processing_data, ProcessingData):
+            continue
+        normalised.append(snapshot)
+    return normalised
 
 
 def _safe_hdf_key(value: str) -> str:
@@ -184,6 +267,66 @@ def _write_trace_indexed(parent: h5py.Group, trace_events: list[dict[str, Any]])
     index_group.create_dataset("any_change", data=any_change, dtype=bool)
 
 
+def _step_groups_by_step_id(parent: h5py.Group) -> dict[str, h5py.Group]:
+    if "steps" not in parent or not isinstance(parent["steps"], h5py.Group):
+        return {}
+
+    steps_group = parent["steps"]
+    out: dict[str, h5py.Group] = {}
+    for key in sorted(steps_group.keys()):
+        step_group = steps_group[key]
+        if not isinstance(step_group, h5py.Group):
+            continue
+        step_id = str(step_group.attrs.get("step_id", key))
+        out.setdefault(step_id, step_group)
+    return out
+
+
+def _write_processing_data_snapshots(
+    parent: h5py.Group,
+    snapshots: list[dict[str, Any]],
+    *,
+    compression: str | None = None,
+) -> None:
+    if not snapshots:
+        return
+
+    parent.attrs["processing_data_snapshot_count"] = len(snapshots)
+    steps_group = parent.require_group("steps")
+    existing_step_groups = _step_groups_by_step_id(parent)
+
+    for idx, snapshot in enumerate(snapshots, start=1):
+        step_id = str(snapshot.get("step_id", "unknown"))
+        step_group = existing_step_groups.get(step_id)
+        if step_group is None:
+            step_key = f"{idx:04d}_{_safe_hdf_key(step_id)}"
+            step_group = steps_group.require_group(step_key)
+            step_group.attrs["step_id"] = step_id
+            step_group.attrs["module"] = str(snapshot.get("module", ""))
+            step_group.attrs["label"] = str(snapshot.get("name", ""))
+            existing_step_groups[step_id] = step_group
+
+        duration_raw = snapshot.get("duration_s")
+        if isinstance(duration_raw, (int, float)):
+            step_group.attrs["duration_s"] = float(duration_raw)
+
+        processing_data = snapshot["processing_data"]
+        snapshot_group = _recreate_group(step_group, "processing_data")
+        snapshot_group.attrs["snapshot_kind"] = "full_processing_data"
+        snapshot_group.attrs["step_id"] = step_id
+        default_path = _write_processing_data_tree(
+            snapshot_group,
+            processing_data,
+            data_paths=None,
+            write_all_processing_data=True,
+            compression=compression,
+        )
+        if default_path is not None:
+            bundle_key, basedata_name = default_path
+            snapshot_group.attrs["default_path"] = f"{bundle_key}/{basedata_name}/signal"
+            step_group.attrs["default_processing_data"] = "processing_data"
+
+
 def _collect_all_basedata_paths(processing_data: ProcessingData) -> list[str]:
     paths: list[str] = []
     for bundle_key in sorted(processing_data.keys()):
@@ -192,6 +335,140 @@ def _collect_all_basedata_paths(processing_data: ProcessingData) -> list[str]:
             if isinstance(databundle[basedata_name], BaseData):
                 paths.append(f"/{bundle_key}/{basedata_name}")
     return paths
+
+
+def _resolve_basedata_paths(
+    processing_data: ProcessingData,
+    data_paths: Sequence[str] | str | None,
+    *,
+    write_all_processing_data: bool = False,
+) -> list[str]:
+    resolved_data_paths: list[str] = []
+    if isinstance(data_paths, str):
+        resolved_data_paths = [data_paths]
+    elif data_paths is not None:
+        resolved_data_paths = [str(path) for path in data_paths]
+
+    if write_all_processing_data:
+        resolved_data_paths.extend(_collect_all_basedata_paths(processing_data))
+
+    return list(dict.fromkeys(resolved_data_paths))
+
+
+def _default_basedata_path(
+    processing_data: ProcessingData,
+    written_basedata_paths: Sequence[tuple[str, str]],
+) -> tuple[str, str] | None:
+    written = list(written_basedata_paths)
+    if not written:
+        return None
+    written_set = set(written)
+
+    for bundle_key in sorted(processing_data.keys()):
+        databundle = processing_data[bundle_key]
+        default_plot = getattr(databundle, "default_plot", None)
+        if default_plot is not None and (bundle_key, str(default_plot)) in written_set:
+            return (bundle_key, str(default_plot))
+
+    for bundle_key, basedata_name in written:
+        if basedata_name == "signal":
+            return (bundle_key, basedata_name)
+
+    return written[0]
+
+
+def _set_processing_tree_defaults(root_group: h5py.Group, default_path: tuple[str, str] | None) -> None:
+    if default_path is None:
+        return
+
+    bundle_key, basedata_name = default_path
+    root_group.attrs["default"] = bundle_key
+    if bundle_key in root_group:
+        bundle_group = root_group[bundle_key]
+        if isinstance(bundle_group, h5py.Group):
+            bundle_group.attrs["default"] = basedata_name
+            if basedata_name in bundle_group and isinstance(bundle_group[basedata_name], h5py.Group):
+                bundle_group[basedata_name].attrs["default"] = "signal"
+
+
+def _write_processing_data_tree(
+    root_group: h5py.Group,
+    processing_data: ProcessingData,
+    data_paths: Sequence[str] | str | None,
+    *,
+    write_all_processing_data: bool = False,
+    compression: str | None = None,
+) -> tuple[str, str] | None:
+    resolved_data_paths = _resolve_basedata_paths(
+        processing_data,
+        data_paths,
+        write_all_processing_data=write_all_processing_data,
+    )
+
+    written_basedata_paths: list[tuple[str, str]] = []
+    seen_basedata_paths: set[tuple[str, str]] = set()
+    for path in resolved_data_paths:
+        parsed = parse_processing_path(path)
+        bundle_key = parsed.databundle_key
+        basedata_name = parsed.basedata_name
+        if bundle_key is None or basedata_name is None:
+            raise ValueError(f"Processing path '{path}' does not reference a BaseData entry.")
+
+        basedata_key = (bundle_key, basedata_name)
+        if basedata_key in seen_basedata_paths:
+            continue
+        seen_basedata_paths.add(basedata_key)
+
+        try:
+            databundle = processing_data[bundle_key]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"ProcessingData missing bundle '{bundle_key}'.") from exc
+
+        try:
+            basedata = databundle[basedata_name]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise KeyError(f"DataBundle '{bundle_key}' missing BaseData '{basedata_name}'.") from exc
+
+        if not isinstance(basedata, BaseData):
+            raise TypeError(
+                f"Processing path '{path}' did not resolve to a BaseData instance (got" f" {type(basedata).__name__})."
+            )
+
+        bundle_group = root_group.require_group(bundle_key)
+        basedata_group = _recreate_group(bundle_group, basedata_name)
+        _write_basedata(
+            basedata_group,
+            basedata,
+            databundle=databundle,
+            basedata_name=basedata_name,
+            compression=compression,
+        )
+        written_basedata_paths.append(basedata_key)
+
+    default_path = _default_basedata_path(processing_data, written_basedata_paths)
+    _set_processing_tree_defaults(root_group, default_path)
+    return default_path
+
+
+def _set_file_default_chain(
+    h5: h5py.File,
+    *,
+    run_name: str,
+    default_path: tuple[str, str] | None,
+) -> None:
+    if default_path is None:
+        return
+
+    bundle_key, basedata_name = default_path
+    h5.attrs["default"] = "processing"
+    processing_group = h5["processing"]
+    processing_group.attrs["default"] = "result"
+    result_root = processing_group["result"]
+    result_root.attrs["default"] = run_name
+    run_result_group = result_root[run_name]
+    run_result_group.attrs["default"] = bundle_key
+    run_result_group[bundle_key].attrs["default"] = basedata_name
+    run_result_group[bundle_key][basedata_name].attrs["default"] = "signal"
 
 
 @define(kw_only=True)
@@ -215,19 +492,14 @@ class HDFProcessingSink(IoSink):
         pipeline_spec: dict[str, Any] | None = None,
         pipeline_yaml: str | None = None,
         trace_events: Any | None = None,
+        processing_data_snapshots: Any | None = None,
         override_resource_location: Path | None = None,
     ) -> Path:
-        resolved_data_paths: list[str] = []
-        if isinstance(data_paths, str):
-            resolved_data_paths = [data_paths]
-        elif data_paths is not None:
-            resolved_data_paths = [str(path) for path in data_paths]
-
-        if write_all_processing_data:
-            resolved_data_paths.extend(_collect_all_basedata_paths(processing_data))
-
-        # Stable order + de-duplication
-        resolved_data_paths = list(dict.fromkeys(resolved_data_paths))
+        resolved_data_paths = _resolve_basedata_paths(
+            processing_data,
+            data_paths,
+            write_all_processing_data=write_all_processing_data,
+        )
         if not resolved_data_paths:
             raise ValueError("HDFProcessingSink.write requires one or more data_paths.")
 
@@ -244,6 +516,12 @@ class HDFProcessingSink(IoSink):
         resolved_trace_events = (
             trace_events if trace_events is not None else self.iosink_method_kwargs.get("trace_events")
         )
+        resolved_processing_data_snapshots = (
+            processing_data_snapshots
+            if processing_data_snapshots is not None
+            else self.iosink_method_kwargs.get("processing_data_snapshots")
+        )
+        normalised_processing_data_snapshots = _normalise_processing_data_snapshots(resolved_processing_data_snapshots)
 
         run_name = _normalise_subpath(subpath)
 
@@ -252,33 +530,13 @@ class HDFProcessingSink(IoSink):
 
             result_root = processing_group.require_group("result")
             run_result_group = _recreate_group(result_root, run_name)
-
-            for path in resolved_data_paths:
-                parsed = parse_processing_path(path)
-                bundle_key = parsed.databundle_key
-                basedata_name = parsed.basedata_name
-                if bundle_key is None or basedata_name is None:
-                    raise ValueError(f"Processing path '{path}' does not reference a BaseData entry.")
-
-                try:
-                    databundle = processing_data[bundle_key]
-                except KeyError as exc:  # pragma: no cover - defensive
-                    raise KeyError(f"ProcessingData missing bundle '{bundle_key}'.") from exc
-
-                try:
-                    basedata = databundle[basedata_name]
-                except KeyError as exc:  # pragma: no cover - defensive
-                    raise KeyError(f"DataBundle '{bundle_key}' missing BaseData '{basedata_name}'.") from exc
-
-                if not isinstance(basedata, BaseData):
-                    raise TypeError(
-                        f"Processing path '{path}' did not resolve to a BaseData instance (got"
-                        f" {type(basedata).__name__})."
-                    )
-
-                bundle_group = run_result_group.require_group(bundle_key)
-                basedata_group = _recreate_group(bundle_group, basedata_name)
-                _write_basedata(basedata_group, basedata, compression=compression)
+            default_path = _write_processing_data_tree(
+                run_result_group,
+                processing_data,
+                resolved_data_paths,
+                compression=compression,
+            )
+            _set_file_default_chain(h5, run_name=run_name, default_path=default_path)
 
             # Pipeline specification (stored as JSON string)
             pipeline_group = processing_group.require_group("pipeline")
@@ -294,11 +552,19 @@ class HDFProcessingSink(IoSink):
             # Trace events: keep raw JSON + indexed structure for querying
             tracer_group = processing_group.require_group("tracer")
             tracer_run_group = _recreate_group(tracer_group, run_name)
-            if resolved_trace_events is None:
+            if resolved_trace_events is None and not normalised_processing_data_snapshots:
                 tracer_run_group.attrs["empty"] = True
             else:
-                tracer_run_group.create_dataset("events", data=_json_dumps_bytes(resolved_trace_events))
-                _write_trace_indexed(tracer_run_group, _normalise_trace_events(resolved_trace_events))
+                if resolved_trace_events is not None:
+                    tracer_run_group.create_dataset("events", data=_json_dumps_bytes(resolved_trace_events))
+                    _write_trace_indexed(tracer_run_group, _normalise_trace_events(resolved_trace_events))
+                else:
+                    tracer_run_group.attrs["schema_version"] = "1.1"
+                _write_processing_data_snapshots(
+                    tracer_run_group,
+                    normalised_processing_data_snapshots,
+                    compression=compression,
+                )
 
         self.logger.info(f"Wrote processing results to {out_path} (run={run_name}).")
         return out_path

--- a/src/modacor/io/runtime_support.py
+++ b/src/modacor/io/runtime_support.py
@@ -166,5 +166,6 @@ def write_processing_data_hdf(
         pipeline_spec=result.pipeline.to_spec(),
         pipeline_yaml=pipeline_yaml,
         trace_events=_flatten_pipeline_trace_events(result.pipeline),
+        processing_data_snapshots=getattr(result.tracer, "processing_data_snapshots", None),
     )
     return str(out_path)

--- a/src/modacor/server/runtime_service.py
+++ b/src/modacor/server/runtime_service.py
@@ -121,6 +121,8 @@ class RuntimeService:
                     "enabled": session.trace_enabled,
                     "watch": session.trace_watch,
                     "record_only_on_change": True,
+                    "snapshot_processing_data": session.trace_snapshot_processing_data,
+                    "snapshot_step_ids": list(session.trace_snapshot_step_ids),
                 },
                 "last_run": session.run_history[-1] if session.run_history else None,
                 "source_profile": session.source_profile,
@@ -165,13 +167,17 @@ class RuntimeService:
             required_source_refs = [str(item["ref"]) for item in profile.get("required_sources", [])]
 
         trace = payload.get("trace", {}) or {}
+        trace_snapshot_step_ids = [str(step_id) for step_id in trace.get("snapshot_step_ids", []) or []]
+        trace_snapshot_processing_data = bool(trace.get("snapshot_processing_data", False) or trace_snapshot_step_ids)
         try:
             session = self.manager.create_session(
                 session_id=session_id,
                 name=payload.get("name"),
                 pipeline_yaml=pipeline_yaml,
-                trace_enabled=bool(trace.get("enabled", False)),
+                trace_enabled=bool(trace.get("enabled", False) or trace_snapshot_processing_data),
                 trace_watch=dict(trace.get("watch", {}) or {}),
+                trace_snapshot_processing_data=trace_snapshot_processing_data,
+                trace_snapshot_step_ids=trace_snapshot_step_ids,
                 auto_full_reset_on_partial_error=bool(payload.get("auto_full_reset_on_partial_error", True)),
                 source_profile=normalized_profile,
                 required_source_refs=required_source_refs,
@@ -626,6 +632,10 @@ class RuntimeService:
             processing_data=session.processing_data if reuse_processing_data else None,
             trace=session.trace_enabled,
             trace_watch=session.trace_watch,
+            tracer_kwargs={
+                "snapshot_processing_data": session.trace_snapshot_processing_data,
+                "snapshot_step_ids": set(session.trace_snapshot_step_ids),
+            },
             selected_step_ids=preparation.selected_step_ids,
         )
         elapsed_s = perf_counter() - run_t0
@@ -760,6 +770,10 @@ class RuntimeService:
                 processing_data=None,
                 trace=session.trace_enabled,
                 trace_watch=session.trace_watch,
+                tracer_kwargs={
+                    "snapshot_processing_data": session.trace_snapshot_processing_data,
+                    "snapshot_step_ids": set(session.trace_snapshot_step_ids),
+                },
             )
             fallback_elapsed = perf_counter() - fallback_t0
             session.processing_data = fallback_result.processing_data

--- a/src/modacor/server/session_manager.py
+++ b/src/modacor/server/session_manager.py
@@ -54,6 +54,8 @@ class PipelineSession:
     pipeline_yaml: str | None = None
     trace_enabled: bool = False
     trace_watch: dict[str, list[str]] = field(default_factory=dict)
+    trace_snapshot_processing_data: bool = False
+    trace_snapshot_step_ids: list[str] = field(default_factory=list)
     auto_full_reset_on_partial_error: bool = True
     sources: dict[str, dict[str, Any]] = field(default_factory=dict)
     sinks: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -90,6 +92,8 @@ class SessionManager:
         pipeline_yaml: str | None = None,
         trace_enabled: bool = False,
         trace_watch: dict[str, list[str]] | None = None,
+        trace_snapshot_processing_data: bool = False,
+        trace_snapshot_step_ids: list[str] | None = None,
         auto_full_reset_on_partial_error: bool = True,
         source_profile: str | None = None,
         required_source_refs: list[str] | None = None,
@@ -103,6 +107,8 @@ class SessionManager:
                 pipeline_yaml=pipeline_yaml,
                 trace_enabled=trace_enabled,
                 trace_watch=trace_watch or {},
+                trace_snapshot_processing_data=trace_snapshot_processing_data,
+                trace_snapshot_step_ids=list(trace_snapshot_step_ids or []),
                 auto_full_reset_on_partial_error=auto_full_reset_on_partial_error,
                 source_profile=source_profile,
                 required_source_refs=list(required_source_refs or []),

--- a/tests/debug/test_tracing_integration.py
+++ b/tests/debug/test_tracing_integration.py
@@ -13,6 +13,11 @@ __status__ = "Development"  # "Development", "Production"
 
 from pathlib import Path
 
+import numpy as np
+
+from modacor import ureg
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
 from modacor.dataclasses.process_step import ProcessStep
 from modacor.dataclasses.process_step_describer import ProcessStepDescriber
 from modacor.dataclasses.processing_data import ProcessingData
@@ -186,3 +191,28 @@ def test_attach_tracer_event_copies_duration():
 
     ev = pipeline.attach_tracer_event(step, tracer)
     assert ev.duration_s == 0.0123
+
+
+def test_tracer_can_capture_processing_data_snapshot_for_selected_step():
+    step_a = DummyStep(io_sources=None, step_id="A")
+    step_b = DummyStep(io_sources=None, step_id="B")
+    processing_data = ProcessingData()
+    bundle = DataBundle()
+    bundle["signal"] = BaseData(signal=np.array([1.0, 2.0]), units=ureg.Unit("count"))
+    processing_data["sample"] = bundle
+
+    tracer = PipelineTracer(
+        watch={"sample": ["signal"]},
+        record_only_on_change=False,
+        snapshot_processing_data=True,
+        snapshot_step_ids={"A"},
+    )
+
+    tracer.after_step(step_a, processing_data)
+    processing_data["sample"]["signal"].signal[0] = 99.0
+    tracer.after_step(step_b, processing_data)
+
+    assert len(tracer.processing_data_snapshots) == 1
+    snapshot = tracer.processing_data_snapshots[0]
+    assert snapshot["step_id"] == "A"
+    np.testing.assert_allclose(snapshot["processing_data"]["sample"]["signal"].signal, np.array([1.0, 2.0]))

--- a/tests/io/hdf/test_hdf_processing_sink.py
+++ b/tests/io/hdf/test_hdf_processing_sink.py
@@ -30,14 +30,23 @@ def processing_data_with_uncertainties() -> ProcessingData:
     pd = ProcessingData()
     bundle = DataBundle()
 
-    signal = np.arange(6, dtype=float).reshape(2, 3)
+    q = BaseData(
+        signal=np.array([0.01, 0.02, 0.03], dtype=float),
+        units=ureg.Unit("1/nm"),
+        rank_of_data=1,
+    )
+    signal = np.arange(3, dtype=float)
     poisson = np.full_like(signal, 0.1, dtype=float)
 
+    bundle["Q"] = q
     bundle["signal"] = BaseData(
         signal=signal,
         units=ureg.Unit("count"),
         uncertainties={"poisson": poisson},
+        axes=[q],
+        rank_of_data=1,
     )
+    bundle.default_plot = "signal"
     pd["sample"] = bundle
     return pd
 
@@ -62,6 +71,10 @@ def _read_str_value(value: str | bytes) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8")
     return str(value)
+
+
+def _read_str_attr_list(value) -> list[str]:
+    return [_read_str_value(item) for item in list(value)]
 
 
 def test_hdf_processing_sink_writes_result_and_metadata(
@@ -100,7 +113,21 @@ def test_hdf_processing_sink_writes_result_and_metadata(
     assert out_file.exists()
 
     with h5py.File(out_file, "r") as h5:
+        assert h5.attrs["default"] == "processing"
+        assert h5["processing"].attrs["default"] == "result"
+        assert h5["processing/result"].attrs["default"] == "run1"
+        assert h5["processing/result/run1"].attrs["default"] == "sample"
+        assert h5["processing/result/run1/sample"].attrs["default"] == "signal"
+
         signal_group = h5["processing/result/run1/sample/signal"]
+        assert signal_group.attrs["default"] == "signal"
+        assert signal_group.attrs["NX_class"] == "NXdata"
+        assert signal_group.attrs["canSAS_class"] == "SASdata"
+        assert signal_group.attrs["signal"] == "signal"
+        assert _read_str_attr_list(signal_group.attrs["axes"]) == ["Q"]
+        assert _read_str_attr_list(signal_group.attrs["I_axes"]) == ["Q"]
+        np.testing.assert_array_equal(signal_group.attrs["Q_indices"], np.array([0], dtype=np.int64))
+
         np.testing.assert_allclose(
             signal_group["signal"], processing_data_with_uncertainties["sample"]["signal"].signal
         )
@@ -184,3 +211,51 @@ def test_hdf_processing_sink_can_write_all_processing_data(tmp_path: Path):
         assert "processing/result/run_all/sample/signal/signal" in h5
         assert "processing/result/run_all/sample/Q/signal" in h5
         assert "processing/result/run_all/sample/note" not in h5
+
+
+def test_hdf_processing_sink_writes_processing_data_snapshots(
+    tmp_path: Path, processing_data_with_uncertainties: ProcessingData
+):
+    out_file = tmp_path / "out_snapshots.h5"
+    sink = HDFProcessingSink(resource_location=out_file)
+
+    trace_events = [
+        {
+            "step_id": "S1",
+            "module": "Example",
+            "duration_s": 0.1,
+            "datasets": {},
+        }
+    ]
+    snapshots = [
+        {
+            "step_id": "S1",
+            "module": "Example",
+            "name": "example",
+            "duration_s": 0.1,
+            "processing_data": processing_data_with_uncertainties,
+        }
+    ]
+
+    sink.write(
+        "run_snap",
+        processing_data_with_uncertainties,
+        data_paths=["/sample/signal/signal"],
+        trace_events=trace_events,
+        processing_data_snapshots=snapshots,
+    )
+
+    with h5py.File(out_file, "r") as h5:
+        tracer_group = h5["processing/tracer/run_snap"]
+        assert tracer_group.attrs["processing_data_snapshot_count"] == 1
+        snapshot_group = tracer_group["steps/0001_S1/processing_data"]
+        assert snapshot_group.attrs["snapshot_kind"] == "full_processing_data"
+        assert snapshot_group.attrs["default"] == "sample"
+        assert snapshot_group["sample"].attrs["default"] == "signal"
+        signal_group = snapshot_group["sample/signal"]
+        assert signal_group.attrs["canSAS_class"] == "SASdata"
+        np.testing.assert_allclose(
+            signal_group["signal"],
+            processing_data_with_uncertainties["sample"]["signal"].signal,
+        )
+        assert "sample/Q/signal" in snapshot_group

--- a/tests/io/test_runtime_support.py
+++ b/tests/io/test_runtime_support.py
@@ -5,14 +5,21 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
+import h5py
+import numpy as np
 import pytest
 from attrs import define, field, validators
 
+from modacor import ureg
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.processing_data import ProcessingData
 from modacor.io.csv.csv_sink import CSVSink
 from modacor.io.hdf.hdf_processing_sink import HDFProcessingSink
 from modacor.io.io_sink import IoSink
-from modacor.io.runtime_support import build_sinks_from_specs
+from modacor.io.runtime_support import build_sinks_from_specs, write_processing_data_hdf
 
 
 @define(kw_only=True)
@@ -97,6 +104,41 @@ def test_build_sinks_from_specs_rejects_unsupported_type(tmp_path: Path):
                 }
             ]
         )
+
+
+def test_write_processing_data_hdf_persists_tracer_snapshots(tmp_path: Path):
+    processing_data = ProcessingData()
+    bundle = DataBundle()
+    bundle["signal"] = BaseData(signal=np.array([1.0, 2.0]), units=ureg.Unit("count"))
+    processing_data["sample"] = bundle
+
+    out_file = tmp_path / "snapshot_export.h5"
+    result = SimpleNamespace(
+        processing_data=processing_data,
+        pipeline=SimpleNamespace(to_spec=lambda: {"name": "demo"}),
+        tracer=SimpleNamespace(
+            processing_data_snapshots=[
+                {
+                    "step_id": "S1",
+                    "module": "Example",
+                    "processing_data": processing_data,
+                }
+            ]
+        ),
+    )
+
+    write_processing_data_hdf(
+        {
+            "path": str(out_file),
+            "data_paths": ["/sample/signal/signal"],
+        },
+        run_name="run1",
+        result=result,
+        pipeline_yaml="name: demo\nsteps: {}\n",
+    )
+
+    with h5py.File(out_file, "r") as h5:
+        assert "processing/tracer/run1/steps/0001_S1/processing_data/sample/signal/signal" in h5
 
 
 def test_build_sinks_from_specs_requires_custom_class_path(tmp_path: Path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -39,6 +40,37 @@ def test_cli_write_hdf_requires_write_path(tmp_path: Path):
                 str(output_path),
             ]
         )
+
+
+def test_cli_run_snapshot_flags_enable_tracer(monkeypatch, tmp_path: Path):
+    pipeline_path = tmp_path / "pipeline.yml"
+    _write_empty_pipeline(pipeline_path)
+    captured = {}
+
+    def fake_run_pipeline_job(*args, **kwargs):  # noqa: ARG001
+        captured.update(kwargs)
+        return SimpleNamespace(
+            executed_steps=[],
+            stopped_after_step=None,
+            tracer=None,
+        )
+
+    monkeypatch.setattr("modacor.cli.run_pipeline_job", fake_run_pipeline_job)
+
+    rc = main(
+        [
+            "run",
+            "--pipeline",
+            str(pipeline_path),
+            "--trace-snapshot-step",
+            "S1",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["trace"] is True
+    assert captured["tracer_kwargs"]["snapshot_processing_data"] is True
+    assert captured["tracer_kwargs"]["snapshot_step_ids"] == {"S1"}
 
 
 def test_cli_serve_parser_accepts_host_port():
@@ -105,6 +137,33 @@ def test_cli_session_create_with_source_template(monkeypatch):
     )
     assert rc == 0
     assert captured["payload"]["source_profile"] == "mouse"
+
+
+def test_cli_session_create_snapshot_flags(monkeypatch):
+    captured = {}
+
+    def fake_http(base_url, method, path, payload=None):  # noqa: ARG001
+        captured["payload"] = payload
+        return {"session_id": "s3"}
+
+    monkeypatch.setattr("modacor.cli._http_request_json", fake_http)
+    rc = main(
+        [
+            "session",
+            "create",
+            "--session-id",
+            "s3",
+            "--pipeline-yaml-text",
+            "name: demo\nsteps: {}\n",
+            "--trace-snapshot-step",
+            "S1",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["payload"]["trace"]["enabled"] is True
+    assert captured["payload"]["trace"]["snapshot_processing_data"] is True
+    assert captured["payload"]["trace"]["snapshot_step_ids"] == ["S1"]
 
 
 def test_cli_session_last_error_calls_api(monkeypatch):


### PR DESCRIPTION
If you want to verify the effect of each step to the actual data, and don't care about the disk space cost, you can add this option to your pipeline runs. It stores specified or all processingData BaseData elements in the trace and the HDF5 processing output file. 