### PR TITLE
fix: adjust the default path to point at signal.

### DIFF
--- a/src/modacor/io/hdf/hdf_processing_sink.py
+++ b/src/modacor/io/hdf/hdf_processing_sink.py
@@ -407,6 +407,14 @@ def _default_basedata_path(
         return None
     written_set = set(written)
 
+    sample_bundle = processing_data.get("sample") if hasattr(processing_data, "get") else None
+    if sample_bundle is not None:
+        sample_default_plot = getattr(sample_bundle, "default_plot", None)
+        if sample_default_plot is not None and ("sample", str(sample_default_plot)) in written_set:
+            return ("sample", str(sample_default_plot))
+        if ("sample", "signal") in written_set:
+            return ("sample", "signal")
+
     for bundle_key in sorted(processing_data.keys()):
         databundle = processing_data[bundle_key]
         default_plot = getattr(databundle, "default_plot", None)

--- a/tests/io/hdf/test_hdf_processing_sink.py
+++ b/tests/io/hdf/test_hdf_processing_sink.py
@@ -260,6 +260,11 @@ def test_hdf_processing_sink_can_write_all_processing_data(tmp_path: Path):
     sink = HDFProcessingSink(resource_location=out_file)
 
     processing_data = ProcessingData()
+    calibration_bundle = DataBundle()
+    calibration_bundle["signal"] = BaseData(signal=np.array([5.0, 6.0]), units=ureg.Unit("count"))
+    calibration_bundle.default_plot = "signal"
+    processing_data["intensity_calibration"] = calibration_bundle
+
     bundle = DataBundle()
     bundle["signal"] = BaseData(signal=np.array([1.0, 2.0]), units=ureg.Unit("count"))
     bundle["Q"] = BaseData(signal=np.array([0.1, 0.2]), units=ureg.Unit("1/nm"))
@@ -274,6 +279,9 @@ def test_hdf_processing_sink_can_write_all_processing_data(tmp_path: Path):
     )
 
     with h5py.File(out_file, "r") as h5:
+        assert h5["processing/result/run_all"].attrs["default"] == "sample"
+        assert _resolve_default_nxdata(h5).name == "/processing/result/run_all/sample/signal"
+        assert "processing/result/run_all/intensity_calibration/signal/signal" in h5
         assert "processing/result/run_all/sample/signal/signal" in h5
         assert "processing/result/run_all/sample/Q/signal" in h5
         assert "processing/result/run_all/sample/note" not in h5


### PR DESCRIPTION
default NeXus path was pointing at the first entity in the result tree, but should point at <default_plot> or sample, if either exists, otherwise fallback to first entry. 