### PR TITLE
adj: Now accepting pixel units as dimensionless - will not be treated

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -21,4 +21,4 @@ repo_main_branch: main
 repo_name: MoDaCor
 repo_userorg: BAMresearch
 sphinx_theme: pydata-sphinx-theme
-version: 1.3.4
+version: 1.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # CHANGELOG
 
+## v1.3.5 (2026-05-24)
+
+### Bug fixes
+
+* fix: adjust tthe default path to point at signal. ([`12ed1f6`](https://github.com/BAMresearch/MoDaCor/commit/12ed1f63b9ef784d676f48e5246cf22f4658e6ac))
+
+* fix: removing nxcanSAS support as MoDaCor is a generic data correction library ([`fdbcd74`](https://github.com/BAMresearch/MoDaCor/commit/fdbcd74d5c552a8831a7c0f33461df159c463545))
+
+* fix: adding NeXus and nxcanSAS compatibility attributes to the output. ([`e7f0d80`](https://github.com/BAMresearch/MoDaCor/commit/e7f0d8049a28007a0d84f7cebf0df99b6eb217d2))
+
+* fix: HDF5 file again not loading in DAWN (but fine in myHDF5 and h5py), trying to improve canSAS adherence ([`c2e5b8f`](https://github.com/BAMresearch/MoDaCor/commit/c2e5b8f1323c301d304590ec16dd2edf3d22ce58))
+
+* fix: working HDF5 file again, now trying to add the NXcanSAS attributes to plot ([`1101707`](https://github.com/BAMresearch/MoDaCor/commit/1101707eb569e8e7721c3bd8748633a22dd40222))
+
+* fix: trying to remove the bits that are the most likely source of trouble: the canSAS attributes and the NX default attributes ([`ef2ab25`](https://github.com/BAMresearch/MoDaCor/commit/ef2ab25737aca08be1f0483b264ed2f18576ba25))
+
+* fix: could it be the encoding of the default attribute? ([`06029a3`](https://github.com/BAMresearch/MoDaCor/commit/06029a35ef83c07cda17fc846859c997a560231f))
+
+### Continuous integration
+
+* ci: reorganizing ([`3d59880`](https://github.com/BAMresearch/MoDaCor/commit/3d59880b7d7aa01b82403da3795be15ce19ed689))
+
+* ci: fixing test dependencies ([`a4a3aac`](https://github.com/BAMresearch/MoDaCor/commit/a4a3aaca2122894de935074fa41a7bc70a8e0925))
+
+### Unknown Scope
+
+* adj: Now accepting pixel units as dimensionless - will not be treated ([`2bfa193`](https://github.com/BAMresearch/MoDaCor/commit/2bfa193c38b607609f181c5b53482f7d4b538c3f))
+
 ## v1.3.4 (2026-05-07)
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MoDaCor (v1.3.4)
+# MoDaCor (v1.3.5)
 
 ## Overview
 
@@ -6,7 +6,7 @@ New modular data corrections for any neutron or X-ray technique that produces 1D
 data.
 
 [![PyPI Package latest release](https://img.shields.io/pypi/v/modacor.svg)](https://pypi.org/project/modacor)
-[![Commits since latest release](https://img.shields.io/github/commits-since/BAMresearch/MoDaCor/v1.3.4.svg)](https://github.com/BAMresearch/MoDaCor/compare/v1.3.4...main)
+[![Commits since latest release](https://img.shields.io/github/commits-since/BAMresearch/MoDaCor/v1.3.5.svg)](https://github.com/BAMresearch/MoDaCor/compare/v1.3.5...main)
 [![License](https://img.shields.io/pypi/l/modacor.svg)](https://en.wikipedia.org/wiki/BSD-3-Clause)
 [![Supported versions](https://img.shields.io/pypi/pyversions/modacor.svg)](https://pypi.org/project/modacor)
 [![PyPI Wheel](https://img.shields.io/pypi/wheel/modacor.svg)](https://pypi.org/project/modacor#files)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ author = (
     "Brian R. Pauw, Malte Storm, Jérôme Kieffer, Ingo Breßler, Anja Hörmann, Glen Smales, Armin Moser, and Tim Snow"
 )
 copyright = "{0}, {1}".format(year, author)
-version = "1.3.4"
+version = "1.3.5"
 release = version
 commit_id = None
 try:

--- a/docs/design/pixel-unit-removal.md
+++ b/docs/design/pixel-unit-removal.md
@@ -1,9 +1,9 @@
-# Pixel Unit Removal
+# Detector Pixel Units
 
-MoDaCor no longer treats detector pixels as physical units. Pint's built-in
-`pixel`, `pixels`, and `px` definitions are removed from the application unit
-registry during startup, and MoDaCor does not replace them with custom detector
-element units.
+MoDaCor treats detector pixels as dimensionless detector-coordinate units. Pint's
+built-in `pixel`, `pixels`, `px`, and related display/CSS pixel definitions are
+removed from the application unit registry during startup, then redefined as
+aliases of a named dimensionless detector pixel unit.
 
 ## Rationale
 
@@ -16,15 +16,20 @@ detector element. The old model also leaked into signal units such as
 The current contract keeps unit handling physical:
 
 - detector element indices and beam-center coordinates are dimensionless,
+- unit strings such as `pixel`, `pixels`, `px`, `css_pixel`, `dot`, `pel`, and
+  `picture_element` are accepted as detector-coordinate aliases,
 - detector element sizes are lengths, for example `m`, `mm`, or `um`,
 - solid angle outputs are `sr`,
 - masks, index maps, and names such as `pixel_index` remain detector-element
-  concepts but do not carry pixel units.
+  concepts and may use either `dimensionless` or a pixel alias.
+
+This deliberately replaces Pint's display/CSS interpretation of pixel-like unit
+names. In MoDaCor, `px` does not mean a CSS length.
 
 ## Migration
 
-Update metadata and pipeline inputs by removing pixel denominators from unit
-strings:
+The preferred metadata style is still to store physical quantities in physical
+units and detector indices as dimensionless values:
 
 | Old unit string | New unit string |
 | --- | --- |
@@ -37,14 +42,19 @@ The numeric values do not change for detector pitch or detector element size.
 For example, a stored pitch value of `0.172` with old units `mm/pixel` becomes
 the same value `0.172` with units `mm`.
 
-## Strict Failure Mode
+For compatibility with existing metadata, pixel denominators are also accepted
+and cancel as dimensionless factors:
 
-This is an intentional breaking change. Unit strings containing `pixel`,
-`pixels`, or `px` now fail during Pint parsing. MoDaCor does not provide a
-compatibility warning or automatic conversion path because silent normalization
-would hide stale metadata.
+- `0.172 mm/pixel` converts to `0.172 mm`,
+- `5 count/px` converts to `5 count`,
+- `10 counts/pixel/second` converts to `10 counts/second`.
 
-External pipeline repositories must update their metadata sources before running
-against this version. In particular, SAXSess and MOUSE-style pipelines that read
-detector pitch from HDF attributes or static YAML must store those pitch units as
-plain length units.
+`BaseData.is_dimensionless` checks Pint compatibility rather than exact unit
+equality, so a `BaseData` stored with `pixel` units is considered dimensionless.
+Calling `BaseData.to_dimensionless()` normalizes compatible named units such as
+`pixel` to Pint's plain `dimensionless` unit without changing the numerical
+values or uncertainties.
+
+External pipeline repositories should prefer updating SAXSess and MOUSE-style
+metadata sources to plain length units for detector pitch, but stale
+`mm/pixel`-style metadata remains parseable.

--- a/docs/pipeline_operations/pipeline_basics.md
+++ b/docs/pipeline_operations/pipeline_basics.md
@@ -69,6 +69,42 @@ correction work:
 This is why MoDaCor can run a correction step and still explain what happened to
 units and propagated uncertainties at each stage.
 
+#### Array casting and broadcasting
+
+When a `BaseData` object is created, scalar values and list-like values supplied
+for `signal`, `uncertainties`, or `weights` are converted to NumPy arrays with a
+floating dtype. Existing `np.ndarray` inputs are kept as arrays and are not
+forcibly recast at construction time.
+
+The `signal` shape defines the stored data shape. Uncertainty arrays and weights
+must be compatible with that shape:
+
+- scalar arrays are accepted for any `signal` shape,
+- arrays that broadcast to exactly `signal.shape` are accepted,
+- arrays that cannot broadcast to `signal.shape`, or would broadcast to a larger
+  shape, are rejected.
+
+For example, for a signal with shape `(4, 5)`, uncertainty shapes `()`, `(5,)`,
+`(1, 5)`, `(4, 1)`, and `(4, 5)` are valid. A shape such as `(6,)` is invalid,
+and so is any shape that would require expanding the signal dimensions.
+
+`rank_of_data` describes how many trailing dimensions are data dimensions, for
+example `2` for detector images. It must be between `0` and `3`, and it cannot
+exceed `signal.ndim`.
+
+#### Detector pixel units
+
+Detector element coordinates are detector indices, not physical display pixels.
+MoDaCor configures Pint so `pixel`, `pixels`, `px`, `css_pixel`, `dot`, `pel`,
+and `picture_element` are accepted as dimensionless detector-coordinate aliases.
+This means beam centers and index maps may use either `dimensionless` or one of
+those aliases.
+
+Detector element sizes remain physical lengths. Prefer storing pitch metadata as
+plain length units such as `m`, `mm`, or `um`. Legacy strings such as
+`mm/pixel`, `count/px`, or `counts/pixel/second` are accepted; the pixel factor
+is dimensionless and cancels during conversion.
+
 ## Sources and sinks
 
 MoDaCor separates external I/O from the pipeline graph itself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "numpy",
     "h5py",
     "pint",
+    "pyyaml",
     "scipy",
 ]
 
@@ -56,7 +57,6 @@ docs = [
 server = [
     "fastapi>=0.110",
     "uvicorn>=0.27",
-    "pyyaml"
 ]
 ci = [
     "tox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ tests = [
     "pytest",
     "pytest-cov",
     "pre-commit",
+    "httpx",
 ]
 lint = [
     "check-manifest",

--- a/src/modacor/__init__.py
+++ b/src/modacor/__init__.py
@@ -14,13 +14,13 @@ __version__ = "1.3.4"
 
 from pint import UnitRegistry, set_application_registry
 
-from .units import remove_pixel_units
+from .units import configure_detector_pixel_units
 
 ureg = UnitRegistry(system="SI")
 
-# Detector element indices are dimensionless in MoDaCor. Remove Pint's
-# display-pixel unit aliases so stale metadata such as "mm/pixel" fails fast.
-remove_pixel_units(ureg)
+# Detector element indices are dimensionless in MoDaCor. Pint's built-in
+# display/CSS pixel units are replaced with detector-coordinate aliases.
+configure_detector_pixel_units(ureg)
 
 # we need to define an arbitrary intensity unit for scaling of intensity data:
 ureg.define("AFU = [flux] = arbitrary_flux_unit")

--- a/src/modacor/__init__.py
+++ b/src/modacor/__init__.py
@@ -10,7 +10,7 @@ __copyright__ = "Copyright 2025, The MoDaCor team"
 __date__ = "22/11/2025"
 __status__ = "Development"  # "Development", "Production"
 
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 from pint import UnitRegistry, set_application_registry
 

--- a/src/modacor/dataclasses/basedata.py
+++ b/src/modacor/dataclasses/basedata.py
@@ -531,7 +531,7 @@ class BaseData(UncertaintyOpsMixin):
     to_base_units(): Converts internal signal and uncertainties to the base units implied by current units.
     to_dimensionless(): Converts internal signal and uncertainties to dimensionless units if possible.
     is_dimensionless() -> bool:
-        Returns True if `units` is dimensionless, False otherwise.
+        Returns True if `units` is compatible with dimensionless, False otherwise.
     """
 
     # required:
@@ -636,7 +636,7 @@ class BaseData(UncertaintyOpsMixin):
         """
         Convert the signal and uncertainties to dimensionless units if possible.
         """
-        if not self.is_dimensionless:
+        if self.units != ureg.dimensionless:
             self.to_units(ureg.dimensionless)
 
     @property
@@ -647,9 +647,9 @@ class BaseData(UncertaintyOpsMixin):
         Returns
         -------
         bool :
-            True if the units are dimensionless, False otherwise.
+            True if the units are compatible with dimensionless, False otherwise.
         """
-        return self.units == ureg.dimensionless
+        return self.units.is_compatible_with(ureg.dimensionless)
 
     def to_base_units(self, *, multiplicative_conversion: bool = True) -> None:
         """
@@ -687,11 +687,9 @@ class BaseData(UncertaintyOpsMixin):
             raise TypeError(f"new_units must be a pint.Unit, got {type(new_units)}.")
 
         if not self.units.is_compatible_with(new_units):
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
               Cannot convert from {self.units} to {new_units}. Units are not compatible.
-            """
-            )
+            """)
 
         # If the units are the same, no conversion is needed
         if self.units == new_units:

--- a/src/modacor/modules/technique_modules/scattering/pixel_coordinates_3d.py
+++ b/src/modacor/modules/technique_modules/scattering/pixel_coordinates_3d.py
@@ -51,7 +51,8 @@ class CanonicalDetectorFrame:
     - det_coord_x: lab-frame x-coordinate of the detector origin. This indicates the offset of the detector origin to the beam center in the lab frame. units of length.
     - det_coord_y: lab-frame y-coordinate of the detector origin. This indicates the offset of the detector origin to the beam center in the lab frame. units of length.
     - e_fast/e_slow/e_normal: unit vectors in lab frame (shape (3,)), defining detector orientation.
-    - pixel_pitch_{slow,fast}: scalar detector-element size in length units
+    - pixel_pitch_{slow,fast}: scalar detector-element size in length units;
+      legacy forms such as mm/pixel are accepted because pixel is dimensionless
 
     Notes:
     Tilt support will be integrated when needed following the NeXus pitch, yaw, roll for rotations around x, y, z.
@@ -167,7 +168,7 @@ class PixelCoordinates3D(ProcessStep):
             "pixel_pitch_slow_units_source": {
                 "type": (str, type(None)),
                 "default": None,
-                "doc": "IoSources key for slow-axis detector element size units.",
+                "doc": "IoSources key for slow-axis detector element size units; prefer length units such as m or mm.",
             },
             "pixel_pitch_slow_uncertainties_sources": {
                 "type": dict,
@@ -183,7 +184,7 @@ class PixelCoordinates3D(ProcessStep):
             "pixel_pitch_fast_units_source": {
                 "type": (str, type(None)),
                 "default": None,
-                "doc": "IoSources key for fast-axis detector element size units.",
+                "doc": "IoSources key for fast-axis detector element size units; prefer length units such as m or mm.",
             },
             "pixel_pitch_fast_uncertainties_sources": {
                 "type": dict,

--- a/src/modacor/modules/technique_modules/scattering/xs_geometry.py
+++ b/src/modacor/modules/technique_modules/scattering/xs_geometry.py
@@ -41,8 +41,10 @@ class XSGeometry(ProcessStep):
     --------------
     * The last `rank_of_data` dimensions of `signal` are the detector dimensions,
     ordered as (..., y, x) for 2D and (..., y) for 1D.
-    * `beam_center.signal` is given in [y, x] dimensionless detector index coordinates for 2D,
-    and [y] for 1D.
+    * `beam_center.signal` is given in [y, x] detector index coordinates for 2D,
+    and [y] for 1D. These coordinates are dimensionless; pixel aliases such as
+    `pixel`, `pixels`, and `px` are accepted as dimensionless detector-coordinate
+    units.
     * `pixel_size.signal` is [pixel_size_y, pixel_size_x] in length units.
     * `pixel_size` is a BaseData vector of length 2 or 3 (length units):
         - first component = pixel size along the "Q0" axis,
@@ -85,7 +87,7 @@ class XSGeometry(ProcessStep):
             "pixel_size_units_source": {
                 "type": (str, type(None)),
                 "default": None,
-                "doc": "IoSources key for detector element size units.",
+                "doc": "IoSources key for detector element size units; prefer length units such as m or mm.",
             },
             "pixel_size_uncertainties_sources": {
                 "type": dict,
@@ -101,7 +103,7 @@ class XSGeometry(ProcessStep):
             "beam_center_units_source": {
                 "type": (str, type(None)),
                 "default": None,
-                "doc": "IoSources key for beam center units.",
+                "doc": "IoSources key for beam center units; dimensionless or detector pixel aliases are accepted.",
             },
             "beam_center_uncertainties_sources": {
                 "type": dict,

--- a/src/modacor/modules/technique_modules/scattering/xs_geometry_from_pixel_coordinates.py
+++ b/src/modacor/modules/technique_modules/scattering/xs_geometry_from_pixel_coordinates.py
@@ -38,7 +38,8 @@ class XSGeometryFromPixelCoordinates(ProcessStep):
     Inputs from configuration sources:
       - sample_z: scalar length (sample is at (0,0,sample_z))
       - wavelength: scalar length
-      - pixel_pitch_fast, pixel_pitch_slow: scalar detector element size in length units (for Omega)
+      - pixel_pitch_fast, pixel_pitch_slow: scalar detector element size in length units (for Omega);
+        legacy forms such as mm/pixel are accepted because pixel is dimensionless
 
     Outputs:
       - Q0, Q1, Q2, Q, Psi, TwoTheta, Omega
@@ -92,7 +93,7 @@ class XSGeometryFromPixelCoordinates(ProcessStep):
             "pixel_pitch_slow_units_source": {
                 "type": (str, type(None)),
                 "default": None,
-                "doc": "IoSources key for slow-axis detector element size units.",
+                "doc": "IoSources key for slow-axis detector element size units; prefer length units such as m or mm.",
             },
             "pixel_pitch_slow_uncertainties_sources": {
                 "type": dict,
@@ -108,7 +109,7 @@ class XSGeometryFromPixelCoordinates(ProcessStep):
             "pixel_pitch_fast_units_source": {
                 "type": (str, type(None)),
                 "default": None,
-                "doc": "IoSources key for fast-axis detector element size units.",
+                "doc": "IoSources key for fast-axis detector element size units; prefer length units such as m or mm.",
             },
             "pixel_pitch_fast_uncertainties_sources": {
                 "type": dict,

--- a/src/modacor/units.py
+++ b/src/modacor/units.py
@@ -84,20 +84,26 @@ def remove_pixel_units(ureg) -> None:
     """
     Remove Pint's display-pixel unit definitions from a registry.
 
-    MoDaCor treats detector element indices as dimensionless array coordinates,
-    not as physical units. After this cleanup, unit strings such as ``pixel``,
-    ``px``, ``mm/pixel`` and ``count/px`` fail during Pint parsing.
+    This is a low-level cleanup helper used before MoDaCor installs its own
+    dimensionless detector-coordinate pixel aliases.
     """
     # Pint's pixel-related aliases vary by version, so delete a small superset.
     _delete_unit_names(ureg, names=PIXEL_UNIT_NAMES)
 
 
+_DETECTOR_PIXEL_DEFINITION = "pixel = 1 = px = pixels"
+_DETECTOR_PIXEL_ALIASES = "@alias pixel = css_pixel = dot = pel = picture_element"
+
+
 def configure_detector_pixel_units(ureg) -> None:
     """
-    Backwards-compatible entry point for registry setup.
+    Configure detector element pixel names as dimensionless units.
 
-    Historically this function redefined ``pixel``/``px`` as detector-element
-    units. The current contract is stricter: detector indices are dimensionless,
-    and pixel unit strings are removed so stale metadata fails fast.
+    Pint ships display/CSS pixel definitions with physical display semantics.
+    MoDaCor detector element indices are array coordinates instead, so we first
+    remove Pint's defaults and then redefine common pixel spellings as aliases
+    of a named unit with scale factor 1.
     """
     remove_pixel_units(ureg)
+    ureg.define(_DETECTOR_PIXEL_DEFINITION)
+    ureg.define(_DETECTOR_PIXEL_ALIASES)

--- a/tests/dataclasses/test_basedata.py
+++ b/tests/dataclasses/test_basedata.py
@@ -303,6 +303,22 @@ def test_to_units_same_units_is_noop(simple_basedata):
     assert bd.units == ureg.dimensionless
 
 
+def test_pixel_units_are_dimensionless_and_can_normalize():
+    bd = BaseData(
+        signal=np.array([1.0, 2.0]),
+        uncertainties={"pixel_index": np.array([0.5, 0.5])},
+        units=ureg.pixel,
+    )
+
+    assert bd.is_dimensionless
+
+    bd.to_dimensionless()
+
+    assert bd.units == ureg.dimensionless
+    np.testing.assert_allclose(bd.signal, [1.0, 2.0])
+    np.testing.assert_allclose(bd.uncertainties["pixel_index"], [0.5, 0.5])
+
+
 def test_to_units_incompatible_units_raises(simple_basedata):
     bd = simple_basedata
     # dimensionless vs. time is not compatible

--- a/tests/modules/base_modules/test_append_processing_data.py
+++ b/tests/modules/base_modules/test_append_processing_data.py
@@ -16,7 +16,6 @@ from typing import Any
 import numpy as np
 import pytest
 from attrs import define, field
-from pint.errors import UndefinedUnitError
 
 from modacor import ureg
 from modacor.dataclasses.basedata import BaseData
@@ -220,7 +219,7 @@ def test_append_processing_data_adds_uncertainties(io_sources, signal_array):
     np.testing.assert_array_equal(bd.uncertainties["sigma"], np.ones_like(signal_array))
 
 
-def test_append_processing_data_rejects_legacy_pixel_unit_metadata(io_sources):
+def test_append_processing_data_accepts_dimensionless_pixel_unit_metadata(io_sources, signal_array):
     source = io_sources.get_source("sample")
     source.metadata["entry/instrument/detector/data@units"] = "mm/pixel"
 
@@ -236,5 +235,9 @@ def test_append_processing_data_rejects_legacy_pixel_unit_metadata(io_sources):
         }
     )
 
-    with pytest.raises(UndefinedUnitError):
-        step.calculate()
+    output = step.calculate()
+    bd = output["sample"]["signal"]
+
+    assert bd.units.is_compatible_with(ureg.millimeter)
+    assert (1.0 * bd.units).to(ureg.millimeter).magnitude == pytest.approx(1.0)
+    np.testing.assert_array_equal(bd.signal, signal_array)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -12,16 +12,15 @@ __status__ = "Development"
 
 import pytest
 from pint import UnitRegistry
-from pint.errors import UndefinedUnitError
 
 from modacor import ureg
-from modacor.units import remove_pixel_units
+from modacor.units import configure_detector_pixel_units
 
 
 @pytest.fixture
-def registry_without_pixels() -> UnitRegistry:
+def registry_with_detector_pixels() -> UnitRegistry:
     ureg = UnitRegistry()
-    remove_pixel_units(ureg)
+    configure_detector_pixel_units(ureg)
     return ureg
 
 
@@ -31,21 +30,36 @@ def registry_without_pixels() -> UnitRegistry:
         "pixel",
         "pixels",
         "px",
-        "mm/pixel",
-        "m/pixel",
-        "count/px",
-        "counts/pixel/second",
+        "css_pixel",
+        "dot",
+        "pel",
+        "picture_element",
     ],
 )
-def test_pixel_unit_strings_are_not_defined(registry_without_pixels: UnitRegistry, unit_string: str) -> None:
-    with pytest.raises(UndefinedUnitError):
-        registry_without_pixels.Unit(unit_string)
+def test_pixel_unit_strings_are_dimensionless(
+    registry_with_detector_pixels: UnitRegistry,
+    unit_string: str,
+) -> None:
+    unit = registry_with_detector_pixels.Unit(unit_string)
+
+    assert unit.is_compatible_with(registry_with_detector_pixels.dimensionless)
+    assert (1 * unit).to(registry_with_detector_pixels.dimensionless).magnitude == pytest.approx(1.0)
+    assert (1 * unit).to_base_units().units == registry_with_detector_pixels.dimensionless
 
 
-def test_application_registry_rejects_pixel_unit_strings() -> None:
-    for unit_string in ("pixel", "pixels", "px", "mm/pixel", "count/px"):
-        with pytest.raises(UndefinedUnitError):
-            ureg.Unit(unit_string)
+def test_application_registry_accepts_dimensionless_pixel_unit_strings() -> None:
+    for unit_string in ("pixel", "pixels", "px", "css_pixel", "dot", "pel", "picture_element"):
+        assert ureg.Unit(unit_string).is_compatible_with(ureg.dimensionless)
+
+
+def test_pixel_denominators_cancel_from_physical_units(registry_with_detector_pixels: UnitRegistry) -> None:
+    pitch = 0.172 * registry_with_detector_pixels.Unit("mm/pixel")
+    counts_per_pixel = 5.0 * registry_with_detector_pixels.Unit("count/px")
+    count_rate_per_pixel = 10.0 * registry_with_detector_pixels.Unit("counts/pixel/second")
+
+    assert pitch.to("mm").magnitude == pytest.approx(0.172)
+    assert counts_per_pixel.to("count").magnitude == pytest.approx(5.0)
+    assert count_rate_per_pixel.to("count/second").magnitude == pytest.approx(10.0)
 
 
 @pytest.mark.parametrize(
@@ -58,27 +72,27 @@ def test_application_registry_rejects_pixel_unit_strings() -> None:
         "1/(m sr)",
     ],
 )
-def test_normal_units_still_parse(registry_without_pixels: UnitRegistry, unit_string: str) -> None:
-    registry_without_pixels.Unit(unit_string)
+def test_normal_units_still_parse(registry_with_detector_pixels: UnitRegistry, unit_string: str) -> None:
+    registry_with_detector_pixels.Unit(unit_string)
 
 
-def test_normal_rate_units_still_convert(registry_without_pixels: UnitRegistry) -> None:
-    rate = 2.0 * registry_without_pixels.count / registry_without_pixels.second
+def test_normal_rate_units_still_convert(registry_with_detector_pixels: UnitRegistry) -> None:
+    rate = 2.0 * registry_with_detector_pixels.count / registry_with_detector_pixels.second
 
     assert rate.to("count/minute").magnitude == pytest.approx(120.0)
 
 
-def test_detector_pitch_is_plain_length(registry_without_pixels: UnitRegistry) -> None:
-    pitch = 0.172 * registry_without_pixels.mm
+def test_detector_pitch_is_plain_length(registry_with_detector_pixels: UnitRegistry) -> None:
+    pitch = 0.172 * registry_with_detector_pixels.mm
     detector_index_delta = 100.0
     length = pitch * detector_index_delta
 
     assert length.to("mm").magnitude == pytest.approx(17.2)
 
 
-def test_detector_element_area_is_plain_area(registry_without_pixels: UnitRegistry) -> None:
-    pitch_fast = 0.172 * registry_without_pixels.mm
-    pitch_slow = 0.200 * registry_without_pixels.mm
+def test_detector_element_area_is_plain_area(registry_with_detector_pixels: UnitRegistry) -> None:
+    pitch_fast = 0.172 * registry_with_detector_pixels.mm
+    pitch_slow = 0.200 * registry_with_detector_pixels.mm
 
     area = pitch_fast * pitch_slow
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     ipykernel
 extras =
     tests  # Installs [project.optional-dependencies.tests]
+    server  # Server API tests are part of the default test suite.
 usedevelop = false
 package = wheel
 # https://tox.wiki/en/latest/user_guide.html#packaging


### PR DESCRIPTION
removing pixel units (see PR #106) also creates issues, so I am now implementing pixels as a dimensionless unit to avoid borking of the units checking when pixels are specified. 