### PR TITLE
Improving server-based operation

### DIFF
--- a/docs/design/api-buffer-source-sink.md
+++ b/docs/design/api-buffer-source-sink.md
@@ -1,0 +1,183 @@
+# API Buffer Source/Sink
+
+Status: implementation plan for the keyed in-memory buffer MVP.
+
+## Goal
+
+MoDaCor should be able to run as a correction engine for externally chunked
+data while keeping the normal `IoSource` and `IoSink` contracts. The external
+pipeline remains responsible for unpacking, chunk selection, retry policy, and
+final repacking. MoDaCor receives the data currently available in a session
+buffer, processes it through a normal pipeline, and writes selected results back
+to a session buffer.
+
+## Data Model
+
+The runtime buffer is session-scoped and keyed by:
+
+```text
+(session_id, kind, ref, data_key)
+```
+
+where `kind` is either `source` or `sink`, `ref` is the registered source/sink
+reference, and `data_key` is the same key passed through `IoSource.get_data()`
+or `IoSink.write()` subpaths.
+
+Array entries are stored internally as `numpy.ndarray`. Metadata and attributes
+are JSON-compatible Python values. Source keys are exact keys, for example:
+
+```text
+sample/signal/signal
+sample/signal/weights
+sample/signal/uncertainties/poisson
+sample/signal@units
+sample/mask/signal
+sample/Q/signal
+sample/Psi/signal
+```
+
+## Wire Format
+
+The MVP supports `.npy` for array upload/download and JSON for metadata.
+`.npy` preserves array shape, signed/unsigned integer dtypes, floating dtypes,
+and array order metadata.
+
+JSON/base64 array transfer is intentionally deferred. The buffer store and
+buffer IO classes only work with `numpy.ndarray`; codecs live at the API
+boundary so additional wire formats can be added later.
+
+## Runtime Registration
+
+Buffer IO is registered like other runtime IO:
+
+```json
+{
+  "sources": [
+    {"ref": "chunk_input", "type": "buffer", "location": "buffer://session"}
+  ],
+  "sinks": [
+    {"ref": "chunk_output", "type": "buffer", "location": "buffer://session"}
+  ]
+}
+```
+
+The `location` value is only a placeholder for registration parity. The actual
+storage is the runtime session buffer.
+
+## Example Pipeline
+
+```yaml
+steps:
+  load_signal:
+    module: AppendProcessingData
+    requires_steps: []
+    configuration:
+      processing_key: sample
+      databundle_output_key: signal
+      signal_location: "chunk_input::sample/signal/signal"
+      units_location: "chunk_input::sample/signal/signal@units"
+      weights_location: "chunk_input::sample/signal/weights"
+      uncertainties_sources:
+        poisson: "chunk_input::sample/signal/uncertainties/poisson"
+      rank_of_data: 2
+
+  load_mask:
+    module: AppendProcessingData
+    requires_steps: []
+    configuration:
+      processing_key: sample
+      databundle_output_key: mask
+      signal_location: "chunk_input::sample/mask/signal"
+      units_override: dimensionless
+      rank_of_data: 2
+
+  export:
+    module: SinkProcessingData
+    requires_steps:
+      - corrected_step
+    configuration:
+      target: "chunk_output::current"
+      data_paths:
+        - /sample/corrected
+```
+
+Masks remain separate `BaseData` entries because `BaseData` has no `mask`
+attribute and existing modules look for `mask`/`Mask` entries in a
+`DataBundle`. Generic axes attachment is deferred for the MVP; axes can be
+loaded as separate `BaseData` entries.
+
+## API
+
+Array upload:
+
+```text
+PUT /v1/sessions/{session_id}/buffers/sources/{source_ref}/arrays/{data_key:path}
+Content-Type: application/x-npy
+```
+
+Array attributes:
+
+```text
+PUT /v1/sessions/{session_id}/buffers/sources/{source_ref}/attrs/{data_key:path}
+Content-Type: application/json
+```
+
+Standalone metadata:
+
+```text
+PUT /v1/sessions/{session_id}/buffers/sources/{source_ref}/metadata/{data_key:path}
+Content-Type: application/json
+```
+
+The metadata payload is an object containing `value`.
+
+Sink array fetch:
+
+```text
+GET /v1/sessions/{session_id}/buffers/sinks/{sink_ref}/arrays/{data_key:path}
+Accept: application/x-npy
+```
+
+Manifest:
+
+```text
+GET /v1/sessions/{session_id}/buffers/{kind}/{ref}/manifest
+```
+
+Clear:
+
+```text
+DELETE /v1/sessions/{session_id}/buffers
+DELETE /v1/sessions/{session_id}/buffers/sinks/{sink_ref}
+DELETE /v1/sessions/{session_id}/buffers/sinks/{sink_ref}/arrays/{data_key:path}
+```
+
+The general clear endpoint supports optional `kind`, `ref`, and `data_key`
+query parameters.
+
+## Memory Behavior
+
+The sink buffer uses latest-only retention. Writing the same sink key overwrites
+the previous value.
+
+Chunk clients should call `/process` with:
+
+```json
+{
+  "mode": "partial",
+  "changed_keys": ["sample.signal"],
+  "rollback_snapshot": false
+}
+```
+
+This avoids deep-copying large chunk-derived `ProcessingData` during partial
+execution. Existing clients keep the previous rollback behavior because the
+default remains `rollback_snapshot: true`.
+
+## Limitations
+
+- Buffer data is in-process memory only and is lost on server restart.
+- MoDaCor does not schedule chunks or repack final arrays.
+- One active run per session remains unchanged.
+- Parallel chunk processing should use separate sessions in the MVP.
+- JSON/base64 array transfer and generic axes attachment are deferred.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -6,6 +6,7 @@ pipeline metadata, and compatibility.
 ```{toctree}
 :maxdepth: 1
 
+api-buffer-source-sink
 io-sink-runtime-api
 pixel-unit-removal
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,26 @@ ci = [
     # generated within tox environments
     "pytest-cov"
 ]
+all = [
+    "build",
+    "check-manifest",
+    "fastapi>=0.110",
+    "flake8",
+    "httpx",
+    "isort",
+    "linkify-it-py",
+    "myst-parser>=2.0",
+    "pre-commit",
+    "pydata-sphinx-theme>=0.14",
+    "pytest",
+    "pytest-cov",
+    "python-semantic-release",
+    "sphinx>=6.2",
+    "sphinxcontrib-mermaid",
+    "toml",
+    "tox",
+    "uvicorn>=0.27",
+]
 
 [[project.authors]]
 name = "Ingo Breßler"

--- a/scripts/reshape_nexus_metadata.py
+++ b/scripts/reshape_nexus_metadata.py
@@ -4,13 +4,14 @@
 
 from __future__ import annotations
 
-"""Make stacked NeXus metadata arrays broadcast cleanly with MoDaCor data arrays.
+"""Make NeXus metadata arrays broadcast cleanly with MoDaCor data arrays.
 
 Standard stacked NeXus files often store per-stack metadata as ``(N,)`` or ``(N, 1)``
 while the main detector data is shaped like ``(N, 1, Y, X)``. NumPy aligns
 broadcasting from the right, so those metadata arrays do not broadcast to the data
 shape. This script appends trailing singleton dimensions, e.g. ``(N, 1)`` becomes
-``(N, 1, 1, 1)``.
+``(N, 1, 1, 1)``. Size-one metadata arrays are left unchanged because they already
+broadcast to the data shape.
 """
 
 import argparse
@@ -74,6 +75,8 @@ def _planned_shape(
     data_shape: tuple[int, ...],
 ) -> tuple[int, ...] | None:
     if not dataset_shape or len(dataset_shape) >= len(data_shape):
+        return None
+    if all(dim == 1 for dim in dataset_shape):
         return None
     if data_shape[: len(dataset_shape)] != dataset_shape:
         return None
@@ -218,7 +221,7 @@ def _default_output_path(input_path: Path) -> Path:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
-            "Append trailing singleton dimensions to stacked NeXus metadata arrays so they "
+            "Append trailing singleton dimensions to NeXus metadata arrays so they "
             "broadcast against MoDaCor's main detector data."
         )
     )

--- a/scripts/reshape_stacked_nexus_metadata.py
+++ b/scripts/reshape_stacked_nexus_metadata.py
@@ -87,6 +87,7 @@ def discover_reshape_plan(
     *,
     data_path: str = DEFAULT_DATA_PATH,
     metadata_paths: Sequence[str] | None = None,
+    exclude_metadata_paths: Sequence[str] | None = None,
     include_non_numeric: bool = False,
 ) -> list[ReshapePlan]:
     """Find metadata datasets that should gain trailing singleton dimensions."""
@@ -100,6 +101,7 @@ def discover_reshape_plan(
     plans: list[ReshapePlan] = []
 
     explicit_paths = bool(metadata_paths)
+    excluded_paths = {_clean_hdf_path(path) for path in exclude_metadata_paths or ()}
 
     def maybe_add(path: str, dataset: h5py.Dataset) -> None:
         if path == data_path:
@@ -123,6 +125,8 @@ def discover_reshape_plan(
     else:
 
         def visitor(path: str, obj: object) -> None:
+            if path in excluded_paths:
+                return
             if isinstance(obj, h5py.Dataset):
                 maybe_add(path, obj)
 
@@ -177,6 +181,7 @@ def convert_file(
     *,
     data_path: str = DEFAULT_DATA_PATH,
     metadata_paths: Sequence[str] | None = None,
+    exclude_metadata_paths: Sequence[str] | None = None,
     include_non_numeric: bool = False,
     dry_run: bool = False,
     overwrite: bool = False,
@@ -198,6 +203,7 @@ def convert_file(
             h5,
             data_path=data_path,
             metadata_paths=metadata_paths,
+            exclude_metadata_paths=exclude_metadata_paths,
             include_non_numeric=include_non_numeric,
         )
         if dry_run:
@@ -253,6 +259,12 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--exclude-metadata-path",
+        action="append",
+        dest="exclude_metadata_paths",
+        help=("Metadata dataset to leave untouched during automatic discovery. " "Repeat to exclude several paths."),
+    )
+    parser.add_argument(
         "--include-non-numeric",
         action="store_true",
         help="Also reshape non-numeric datasets during automatic discovery.",
@@ -272,6 +284,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         output_path,
         data_path=args.data_path,
         metadata_paths=args.metadata_paths,
+        exclude_metadata_paths=args.exclude_metadata_paths,
         include_non_numeric=args.include_non_numeric,
         dry_run=args.dry_run,
         overwrite=args.overwrite,

--- a/scripts/reshape_stacked_nexus_metadata.py
+++ b/scripts/reshape_stacked_nexus_metadata.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+"""Make stacked NeXus metadata arrays broadcast cleanly with MoDaCor data arrays.
+
+Standard stacked NeXus files often store per-stack metadata as ``(N,)`` or ``(N, 1)``
+while the main detector data is shaped like ``(N, 1, Y, X)``. NumPy aligns
+broadcasting from the right, so those metadata arrays do not broadcast to the data
+shape. This script appends trailing singleton dimensions, e.g. ``(N, 1)`` becomes
+``(N, 1, 1, 1)``.
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import numpy as np
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _maybe_reexec_with_local_venv() -> None:
+    """Retry with a project-local interpreter if current Python misses deps."""
+    if os.environ.get("MODACOR_NEXUS_RESHAPE_REEXEC") == "1":
+        return
+
+    for candidate in (PROJECT_ROOT / ".venv" / "bin" / "python", PROJECT_ROOT / ".venv-dev" / "bin" / "python"):
+        if not candidate.exists():
+            continue
+        if Path(sys.executable).resolve() == candidate.resolve():
+            continue
+
+        env = dict(os.environ)
+        env["MODACOR_NEXUS_RESHAPE_REEXEC"] = "1"
+        completed = subprocess.run([str(candidate), *sys.argv], env=env, check=False)
+        raise SystemExit(completed.returncode)
+
+
+try:
+    import h5py
+except ModuleNotFoundError:
+    _maybe_reexec_with_local_venv()
+    raise
+
+
+DEFAULT_DATA_PATH = "entry1/instrument/detector00/data"
+
+
+@dataclass(frozen=True)
+class ReshapePlan:
+    path: str
+    old_shape: tuple[int, ...]
+    new_shape: tuple[int, ...]
+
+
+def _clean_hdf_path(path: str) -> str:
+    return path.strip("/")
+
+
+def _is_numeric_dataset(dataset: h5py.Dataset) -> bool:
+    return np.issubdtype(dataset.dtype, np.number) or np.issubdtype(dataset.dtype, np.bool_)
+
+
+def _planned_shape(
+    dataset_shape: tuple[int, ...],
+    data_shape: tuple[int, ...],
+) -> tuple[int, ...] | None:
+    if not dataset_shape or len(dataset_shape) >= len(data_shape):
+        return None
+    if data_shape[: len(dataset_shape)] != dataset_shape:
+        return None
+
+    trailing_dims = len(data_shape) - len(dataset_shape)
+    return dataset_shape + (1,) * trailing_dims
+
+
+def discover_reshape_plan(
+    h5: h5py.File,
+    *,
+    data_path: str = DEFAULT_DATA_PATH,
+    metadata_paths: Sequence[str] | None = None,
+    include_non_numeric: bool = False,
+) -> list[ReshapePlan]:
+    """Find metadata datasets that should gain trailing singleton dimensions."""
+    data_path = _clean_hdf_path(data_path)
+    if data_path not in h5:
+        raise KeyError(f"Main data path not found: {data_path}")
+    if not isinstance(h5[data_path], h5py.Dataset):
+        raise TypeError(f"Main data path is not a dataset: {data_path}")
+
+    data_shape = tuple(h5[data_path].shape)
+    plans: list[ReshapePlan] = []
+
+    explicit_paths = bool(metadata_paths)
+
+    def maybe_add(path: str, dataset: h5py.Dataset) -> None:
+        if path == data_path:
+            return
+        if not explicit_paths and not include_non_numeric and not _is_numeric_dataset(dataset):
+            return
+        new_shape = _planned_shape(tuple(dataset.shape), data_shape)
+        if new_shape is None or new_shape == tuple(dataset.shape):
+            return
+        plans.append(ReshapePlan(path=path, old_shape=tuple(dataset.shape), new_shape=new_shape))
+
+    if metadata_paths:
+        for raw_path in metadata_paths:
+            path = _clean_hdf_path(raw_path)
+            if path not in h5:
+                raise KeyError(f"Metadata path not found: {path}")
+            dataset = h5[path]
+            if not isinstance(dataset, h5py.Dataset):
+                raise TypeError(f"Metadata path is not a dataset: {path}")
+            maybe_add(path, dataset)
+    else:
+
+        def visitor(path: str, obj: object) -> None:
+            if isinstance(obj, h5py.Dataset):
+                maybe_add(path, obj)
+
+        h5.visititems(visitor)
+
+    return plans
+
+
+def _creation_kwargs(dataset: h5py.Dataset, new_shape: tuple[int, ...]) -> dict:
+    kwargs = {
+        "dtype": dataset.dtype,
+        "compression": dataset.compression,
+        "compression_opts": dataset.compression_opts,
+        "shuffle": dataset.shuffle,
+        "fletcher32": dataset.fletcher32,
+        "scaleoffset": dataset.scaleoffset,
+    }
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+
+    if dataset.chunks is not None:
+        trailing_dims = len(new_shape) - len(dataset.shape)
+        kwargs["chunks"] = tuple(dataset.chunks) + (1,) * trailing_dims
+        kwargs["maxshape"] = tuple(dataset.maxshape) + (1,) * trailing_dims
+
+    return kwargs
+
+
+def apply_reshape_plan(h5: h5py.File, plans: Iterable[ReshapePlan]) -> list[ReshapePlan]:
+    """Rewrite each planned dataset with the requested shape, preserving values and attrs."""
+    applied: list[ReshapePlan] = []
+
+    for plan in plans:
+        dataset = h5[plan.path]
+        data = dataset[()].reshape(plan.new_shape)
+        attrs = {key: dataset.attrs[key] for key in dataset.attrs}
+        kwargs = _creation_kwargs(dataset, plan.new_shape)
+
+        parent_path, dataset_name = plan.path.rsplit("/", 1) if "/" in plan.path else ("", plan.path)
+        parent = h5[parent_path] if parent_path else h5
+        del parent[dataset_name]
+        new_dataset = parent.create_dataset(dataset_name, data=data, **kwargs)
+        for key, value in attrs.items():
+            new_dataset.attrs[key] = value
+        applied.append(plan)
+
+    return applied
+
+
+def convert_file(
+    input_path: Path,
+    output_path: Path | None,
+    *,
+    data_path: str = DEFAULT_DATA_PATH,
+    metadata_paths: Sequence[str] | None = None,
+    include_non_numeric: bool = False,
+    dry_run: bool = False,
+    overwrite: bool = False,
+) -> list[ReshapePlan]:
+    """Copy *input_path* to *output_path* and reshape compatible metadata arrays."""
+    input_path = Path(input_path)
+    if not input_path.is_file():
+        raise FileNotFoundError(input_path)
+
+    target_path = Path(output_path) if output_path is not None else input_path
+    if target_path != input_path and not dry_run:
+        if target_path.exists() and not overwrite:
+            raise FileExistsError(f"Output file exists: {target_path}")
+        shutil.copy2(input_path, target_path)
+
+    mode = "r" if dry_run else "r+"
+    with h5py.File(target_path if not dry_run else input_path, mode) as h5:
+        plans = discover_reshape_plan(
+            h5,
+            data_path=data_path,
+            metadata_paths=metadata_paths,
+            include_non_numeric=include_non_numeric,
+        )
+        if dry_run:
+            return plans
+        return apply_reshape_plan(h5, plans)
+
+
+def _default_output_path(input_path: Path) -> Path:
+    return input_path.with_name(f"{input_path.stem}_modacor{input_path.suffix}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Append trailing singleton dimensions to stacked NeXus metadata arrays so they "
+            "broadcast against MoDaCor's main detector data."
+        )
+    )
+    parser.add_argument("input", type=Path, help="Input HDF5/NeXus file.")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        type=Path,
+        help="Output file. Defaults to '<input stem>_modacor<input suffix>'.",
+    )
+    parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Modify the input file directly instead of writing a converted copy.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Allow replacing an existing output file.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report datasets that would be reshaped without writing changes.",
+    )
+    parser.add_argument(
+        "--data-path",
+        default=DEFAULT_DATA_PATH,
+        help=f"Main detector data dataset path. Default: {DEFAULT_DATA_PATH}",
+    )
+    parser.add_argument(
+        "--metadata-path",
+        action="append",
+        dest="metadata_paths",
+        help=(
+            "Metadata dataset to reshape. Repeat to list several paths. "
+            "When omitted, numeric prefix-shaped datasets are discovered automatically."
+        ),
+    )
+    parser.add_argument(
+        "--include-non-numeric",
+        action="store_true",
+        help="Also reshape non-numeric datasets during automatic discovery.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.in_place and args.output is not None:
+        raise SystemExit("Use either --in-place or an output path, not both.")
+
+    output_path = None if args.in_place else (args.output or _default_output_path(args.input))
+    plans = convert_file(
+        args.input,
+        output_path,
+        data_path=args.data_path,
+        metadata_paths=args.metadata_paths,
+        include_non_numeric=args.include_non_numeric,
+        dry_run=args.dry_run,
+        overwrite=args.overwrite,
+    )
+
+    target = args.input if args.in_place or args.dry_run else output_path
+    action = "Would reshape" if args.dry_run else "Reshaped"
+    print(f"{action} {len(plans)} dataset(s) in {target}:")
+    for plan in plans:
+        print(f"  {plan.path}: {plan.old_shape} -> {plan.new_shape}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/modacor/dataclasses/helpers.py
+++ b/src/modacor/dataclasses/helpers.py
@@ -23,6 +23,7 @@ def basedata_from_sources(
     signal_source: str,
     units_source: str | None = None,
     uncertainty_sources: dict[str, str] = {},
+    weights_source: str | None = None,
 ) -> BaseData:
     """Helper function to build a BaseData object from IoSources
 
@@ -38,8 +39,13 @@ def basedata_from_sources(
         In that case, it can be specified by 'key to the dataset@[units_attribute_name]'
     uncertainty_sources : dict[str, str], optional
         A dictionary mapping uncertainty names to their source keys, by default an empty dictionary.
+    weights_source : str | None, optional
+        Optional source key for BaseData weights, by default None.
     """
     signal = io_sources.get_data(signal_source)
     units = ureg.Unit(io_sources.get_static_metadata(units_source)) if units_source is not None else ureg.dimensionless
     uncertainties = {name: io_sources.get_data(source) for name, source in uncertainty_sources.items()}
-    return BaseData(signal=signal, units=units, uncertainties=uncertainties)
+    kwargs = {"signal": signal, "units": units, "uncertainties": uncertainties}
+    if weights_source is not None:
+        kwargs["weights"] = io_sources.get_data(weights_source)
+    return BaseData(**kwargs)

--- a/src/modacor/io/__init__.py
+++ b/src/modacor/io/__init__.py
@@ -25,9 +25,10 @@
 __license__ = "BSD-3-Clause"
 __copyright__ = "Copyright 2025 MoDaCor Authors"
 __status__ = "Alpha"
-__all__ = ["IoSource", "IoSources", "TiledSource"]
+__all__ = ["BufferSink", "BufferSource", "IoSource", "IoSources", "RuntimeBufferStore", "TiledSource"]
 
 
+from .buffer import BufferSink, BufferSource, RuntimeBufferStore
 from .io_source import IoSource
 from .io_sources import IoSources
 from .tiled.tiled_source import TiledSource

--- a/src/modacor/io/buffer/__init__.py
+++ b/src/modacor/io/buffer/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from .buffer_sink import BufferSink
+from .buffer_source import BufferSource
+from .codec import decode_npy, encode_npy
+from .runtime_buffer_store import RuntimeBufferStore
+
+__all__ = ["BufferSink", "BufferSource", "RuntimeBufferStore", "decode_npy", "encode_npy"]

--- a/src/modacor/io/buffer/buffer_sink.py
+++ b/src/modacor/io/buffer/buffer_sink.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import Any, Sequence
+
+import numpy as np
+from attrs import define, field, validators
+
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.buffer.runtime_buffer_store import RuntimeBufferStore
+from modacor.io.io_sink import IoSink
+from modacor.io.processing_path import parse_processing_path, resolve_processing_path
+
+__all__ = ["BufferSink"]
+
+
+def _join_key(*parts: str) -> str:
+    cleaned: list[str] = []
+    for part in parts:
+        value = str(part).strip().strip("/")
+        if value:
+            cleaned.extend(item for item in PurePosixPath(value).parts if item != "/")
+    return "/".join(cleaned)
+
+
+def _normalise_data_paths(data_paths: Sequence[str] | str | None) -> list[str]:
+    if isinstance(data_paths, str):
+        return [data_paths]
+    if data_paths is None:
+        return []
+    return [str(path) for path in data_paths]
+
+
+@define(kw_only=True)
+class BufferSink(IoSink):
+    """IoSink that writes selected ProcessingData entries into the runtime buffer."""
+
+    resource_location: Path | str | None = field(
+        default=None,
+        validator=validators.optional(validators.instance_of((Path, str))),
+    )
+    session_id: str = field(validator=validators.instance_of(str))
+    buffer_store: RuntimeBufferStore = field(validator=validators.instance_of(RuntimeBufferStore))
+    iosink_method_kwargs: dict[str, Any] = field(factory=dict, validator=validators.instance_of(dict))
+
+    def _put_array(self, data_key: str, value: Any) -> None:
+        self.buffer_store.put_array(self.session_id, "sink", self.sink_reference, data_key, np.asarray(value))
+
+    def _put_basedata(self, prefix: str, bundle_key: str, basedata_name: str, basedata: BaseData) -> list[str]:
+        base_key = _join_key(prefix, bundle_key, basedata_name)
+        written = []
+        signal_key = _join_key(base_key, "signal")
+        self._put_array(signal_key, basedata.signal)
+        written.append(signal_key)
+        self.buffer_store.update_attrs(
+            self.session_id,
+            "sink",
+            self.sink_reference,
+            signal_key,
+            {
+                "units": str(basedata.units),
+                "rank_of_data": int(basedata.rank_of_data),
+            },
+        )
+
+        weights_key = _join_key(base_key, "weights")
+        self._put_array(weights_key, basedata.weights)
+        written.append(weights_key)
+        for name, uncertainty in basedata.uncertainties.items():
+            uncertainty_key = _join_key(base_key, "uncertainties", str(name))
+            self._put_array(uncertainty_key, uncertainty)
+            written.append(uncertainty_key)
+        return written
+
+    def write(
+        self,
+        subpath: str,
+        processing_data: ProcessingData,
+        data_paths: Sequence[str] | str | None,
+        **kwargs: Any,  # noqa: ARG002
+    ) -> dict[str, list[str]]:
+        paths = _normalise_data_paths(data_paths)
+        if not paths:
+            raise ValueError("BufferSink.write requires one or more data_paths.")
+
+        written_arrays: list[str] = []
+        written_metadata: list[str] = []
+        prefix = _join_key(subpath)
+
+        for path in paths:
+            parsed = parse_processing_path(path)
+            if not parsed.subpath:
+                basedata = processing_data[parsed.databundle_key][parsed.basedata_name]
+                if not isinstance(basedata, BaseData):
+                    raise TypeError(f"Processing path '{path}' did not resolve to a BaseData instance.")
+                written_arrays.extend(self._put_basedata(prefix, parsed.databundle_key, parsed.basedata_name, basedata))
+                continue
+
+            value = resolve_processing_path(processing_data, path)
+            data_key = _join_key(prefix, parsed.databundle_key, parsed.basedata_name, *parsed.subpath)
+            if isinstance(value, BaseData):
+                written_arrays.extend(self._put_basedata(prefix, parsed.databundle_key, parsed.basedata_name, value))
+            elif isinstance(value, (np.ndarray, int, float, complex, bool, np.number)):
+                self._put_array(data_key, value)
+                written_arrays.append(data_key)
+            else:
+                self.buffer_store.put_metadata(
+                    self.session_id,
+                    "sink",
+                    self.sink_reference,
+                    data_key,
+                    str(value),
+                )
+                written_metadata.append(data_key)
+
+        return {"arrays": list(dict.fromkeys(written_arrays)), "metadata": list(dict.fromkeys(written_metadata))}

--- a/src/modacor/io/buffer/buffer_source.py
+++ b/src/modacor/io/buffer/buffer_source.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from attrs import define, field, validators
+
+from modacor.io.buffer.runtime_buffer_store import RuntimeBufferStore
+from modacor.io.io_source import ArraySlice, IoSource
+
+__all__ = ["BufferSource"]
+
+
+@define(kw_only=True)
+class BufferSource(IoSource):
+    """IoSource backed by the runtime session buffer."""
+
+    resource_location: Path | str | None = field(
+        default=None,
+        validator=validators.optional(validators.instance_of((Path, str))),
+    )
+    session_id: str = field(validator=validators.instance_of(str))
+    buffer_store: RuntimeBufferStore = field(validator=validators.instance_of(RuntimeBufferStore))
+
+    def get_data(self, data_key: str, load_slice: ArraySlice = ...) -> np.ndarray:
+        array = self.buffer_store.get_array(self.session_id, "source", self.source_reference, data_key)
+        if load_slice is None or load_slice is Ellipsis:
+            return array
+        return array[load_slice]
+
+    def get_data_shape(self, data_key: str) -> tuple[int, ...]:
+        return self.buffer_store.get_array_shape(self.session_id, "source", self.source_reference, data_key)
+
+    def get_data_dtype(self, data_key: str) -> np.dtype | None:
+        return self.buffer_store.get_array_dtype(self.session_id, "source", self.source_reference, data_key)
+
+    def get_data_attributes(self, data_key: str) -> dict[str, Any]:
+        return self.buffer_store.get_attrs(self.session_id, "source", self.source_reference, data_key)
+
+    def get_static_metadata(self, data_key: str) -> Any:
+        if "@" in data_key:
+            array_key, attr_key = data_key.rsplit("@", 1)
+            attrs = self.get_data_attributes(array_key)
+            if attr_key not in attrs:
+                raise KeyError(
+                    f"Buffer attribute '{attr_key}' not found for source '{self.source_reference}' key '{array_key}'."
+                )
+            return attrs[attr_key]
+        return self.buffer_store.get_metadata(self.session_id, "source", self.source_reference, data_key)

--- a/src/modacor/io/buffer/codec.py
+++ b/src/modacor/io/buffer/codec.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import numpy as np
+
+__all__ = ["decode_npy", "encode_npy"]
+
+
+def encode_npy(array: np.ndarray) -> bytes:
+    """Encode one array as NumPy .npy bytes."""
+
+    stream = BytesIO()
+    np.save(stream, np.asarray(array), allow_pickle=False)
+    return stream.getvalue()
+
+
+def decode_npy(payload: bytes) -> np.ndarray:
+    """Decode NumPy .npy bytes into an array."""
+
+    stream = BytesIO(payload)
+    array = np.load(stream, allow_pickle=False)
+    if not isinstance(array, np.ndarray):
+        raise ValueError("Decoded .npy payload did not contain a NumPy array.")
+    return array

--- a/src/modacor/io/buffer/runtime_buffer_store.py
+++ b/src/modacor/io/buffer/runtime_buffer_store.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from copy import deepcopy
+from threading import RLock
+from typing import Any, Literal
+
+import numpy as np
+from attrs import define, field
+
+__all__ = ["BufferKind", "RuntimeBufferStore"]
+
+BufferKind = Literal["source", "sink"]
+
+
+def _normalise_kind(kind: str) -> BufferKind:
+    value = str(kind).strip().lower()
+    if value in {"source", "sources"}:
+        return "source"
+    if value in {"sink", "sinks"}:
+        return "sink"
+    raise ValueError("Buffer kind must be 'source' or 'sink'.")
+
+
+def _normalise_key(data_key: str) -> str:
+    key = str(data_key).strip()
+    if not key:
+        raise ValueError("Buffer data_key must be non-empty.")
+    return key.strip("/")
+
+
+@define
+class RuntimeBufferStore:
+    """Thread-safe in-memory storage for runtime buffer sources and sinks."""
+
+    _arrays: dict[tuple[str, BufferKind, str, str], np.ndarray] = field(factory=dict, init=False)
+    _attrs: dict[tuple[str, BufferKind, str, str], dict[str, Any]] = field(factory=dict, init=False)
+    _metadata: dict[tuple[str, BufferKind, str, str], Any] = field(factory=dict, init=False)
+    _lock: RLock = field(factory=RLock, init=False)
+
+    def _entry_key(self, session_id: str, kind: str, ref: str, data_key: str) -> tuple[str, BufferKind, str, str]:
+        session = str(session_id).strip()
+        reference = str(ref).strip()
+        if not session:
+            raise ValueError("session_id must be non-empty.")
+        if not reference:
+            raise ValueError("Buffer ref must be non-empty.")
+        return (session, _normalise_kind(kind), reference, _normalise_key(data_key))
+
+    def put_array(self, session_id: str, kind: str, ref: str, data_key: str, array: np.ndarray) -> None:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            self._arrays[key] = np.array(array, copy=True)
+
+    def get_array(self, session_id: str, kind: str, ref: str, data_key: str) -> np.ndarray:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            try:
+                return np.array(self._arrays[key], copy=True)
+            except KeyError as exc:
+                raise KeyError(f"Buffer array not found for {key[1]} '{key[2]}' key '{key[3]}'.") from exc
+
+    def has_array(self, session_id: str, kind: str, ref: str, data_key: str) -> bool:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            return key in self._arrays
+
+    def get_array_shape(self, session_id: str, kind: str, ref: str, data_key: str) -> tuple[int, ...]:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            array = self._arrays.get(key)
+            return tuple(array.shape) if array is not None else ()
+
+    def get_array_dtype(self, session_id: str, kind: str, ref: str, data_key: str) -> np.dtype | None:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            array = self._arrays.get(key)
+            return None if array is None else array.dtype
+
+    def put_attrs(self, session_id: str, kind: str, ref: str, data_key: str, attrs: dict[str, Any]) -> None:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            self._attrs[key] = dict(attrs)
+
+    def update_attrs(self, session_id: str, kind: str, ref: str, data_key: str, attrs: dict[str, Any]) -> None:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            current = dict(self._attrs.get(key, {}))
+            current.update(attrs)
+            self._attrs[key] = current
+
+    def get_attrs(self, session_id: str, kind: str, ref: str, data_key: str) -> dict[str, Any]:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            return dict(self._attrs.get(key, {}))
+
+    def put_metadata(self, session_id: str, kind: str, ref: str, data_key: str, value: Any) -> None:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            self._metadata[key] = deepcopy(value)
+
+    def get_metadata(self, session_id: str, kind: str, ref: str, data_key: str) -> Any:
+        key = self._entry_key(session_id, kind, ref, data_key)
+        with self._lock:
+            if key not in self._metadata:
+                raise KeyError(f"Buffer metadata not found for {key[1]} '{key[2]}' key '{key[3]}'.")
+            return deepcopy(self._metadata[key])
+
+    def manifest(self, session_id: str, kind: str, ref: str) -> dict[str, Any]:
+        normal_kind = _normalise_kind(kind)
+        session = str(session_id).strip()
+        reference = str(ref).strip()
+        with self._lock:
+            arrays = sorted(
+                key for sid, k, r, key in self._arrays if sid == session and k == normal_kind and r == reference
+            )
+            attrs = sorted(
+                key for sid, k, r, key in self._attrs if sid == session and k == normal_kind and r == reference
+            )
+            metadata = sorted(
+                key for sid, k, r, key in self._metadata if sid == session and k == normal_kind and r == reference
+            )
+            array_details = {}
+            for data_key in arrays:
+                array = self._arrays[(session, normal_kind, reference, data_key)]
+                array_details[data_key] = {"shape": list(array.shape), "dtype": str(array.dtype)}
+        return {
+            "session_id": session,
+            "kind": normal_kind,
+            "ref": reference,
+            "arrays": arrays,
+            "attrs": attrs,
+            "metadata": metadata,
+            "array_details": array_details,
+        }
+
+    def clear(
+        self,
+        session_id: str,
+        *,
+        kind: str | None = None,
+        ref: str | None = None,
+        data_key: str | None = None,
+    ) -> int:
+        session = str(session_id).strip()
+        normal_kind = _normalise_kind(kind) if kind is not None else None
+        normal_ref = str(ref).strip() if ref is not None else None
+        normal_data_key = _normalise_key(data_key) if data_key is not None else None
+
+        def matches(entry: tuple[str, BufferKind, str, str]) -> bool:
+            sid, entry_kind, entry_ref, entry_key = entry
+            return (
+                sid == session
+                and (normal_kind is None or entry_kind == normal_kind)
+                and (normal_ref is None or entry_ref == normal_ref)
+                and (normal_data_key is None or entry_key == normal_data_key)
+            )
+
+        removed = 0
+        with self._lock:
+            for storage in (self._arrays, self._attrs, self._metadata):
+                for key in [entry for entry in storage if matches(entry)]:
+                    del storage[key]
+                    removed += 1
+        return removed

--- a/src/modacor/io/runtime_support.py
+++ b/src/modacor/io/runtime_support.py
@@ -8,6 +8,9 @@ from importlib import import_module
 from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+from modacor.io.buffer.buffer_sink import BufferSink
+from modacor.io.buffer.buffer_source import BufferSource
+from modacor.io.buffer.runtime_buffer_store import RuntimeBufferStore
 from modacor.io.csv.csv_sink import CSVSink
 from modacor.io.csv.csv_source import CSVSource
 from modacor.io.hdf.hdf_processing_sink import HDFProcessingSink
@@ -25,7 +28,12 @@ def _load_custom_class(class_path: str):
     return getattr(module, class_name)
 
 
-def build_sources_from_specs(specs: Iterable[Mapping[str, Any]]) -> IoSources:
+def build_sources_from_specs(
+    specs: Iterable[Mapping[str, Any]],
+    *,
+    buffer_store: RuntimeBufferStore | None = None,
+    session_id: str | None = None,
+) -> IoSources:
     """
     Build an :class:`IoSources` registry from normalized source specifications.
 
@@ -35,6 +43,7 @@ def build_sources_from_specs(specs: Iterable[Mapping[str, Any]]) -> IoSources:
     """
 
     type_map: dict[str, Any] = {
+        "buffer": BufferSource,
         "csv": CSVSource,
         "hdf": HDFSource,
         "yaml": YAMLSource,
@@ -58,17 +67,33 @@ def build_sources_from_specs(specs: Iterable[Mapping[str, Any]]) -> IoSources:
             except KeyError as exc:
                 raise ValueError(f"Unsupported source type '{source_type}' for ref '{ref}'.") from exc
 
-        source = source_cls(
-            source_reference=ref,
-            resource_location=location,
-            iosource_method_kwargs=kwargs.get("iosource_method_kwargs", kwargs),
-        )
+        if source_cls is BufferSource:
+            if buffer_store is None or session_id is None:
+                raise ValueError(f"Buffer source '{ref}' requires runtime buffer_store and session_id.")
+            source = source_cls(
+                source_reference=ref,
+                resource_location=str(spec["location"]),
+                iosource_method_kwargs=kwargs.get("iosource_method_kwargs", kwargs),
+                buffer_store=buffer_store,
+                session_id=str(session_id),
+            )
+        else:
+            source = source_cls(
+                source_reference=ref,
+                resource_location=location,
+                iosource_method_kwargs=kwargs.get("iosource_method_kwargs", kwargs),
+            )
         sources.register_source(source)
 
     return sources
 
 
-def build_sinks_from_specs(specs: Iterable[Mapping[str, Any]]) -> IoSinks:
+def build_sinks_from_specs(
+    specs: Iterable[Mapping[str, Any]],
+    *,
+    buffer_store: RuntimeBufferStore | None = None,
+    session_id: str | None = None,
+) -> IoSinks:
     """
     Build an :class:`IoSinks` registry from normalized sink specifications.
 
@@ -78,6 +103,7 @@ def build_sinks_from_specs(specs: Iterable[Mapping[str, Any]]) -> IoSinks:
     """
 
     type_map: dict[str, Any] = {
+        "buffer": BufferSink,
         "csv": CSVSink,
         "hdf": HDFProcessingSink,
         "hdf_processing": HDFProcessingSink,
@@ -100,11 +126,22 @@ def build_sinks_from_specs(specs: Iterable[Mapping[str, Any]]) -> IoSinks:
             except KeyError as exc:
                 raise ValueError(f"Unsupported sink type '{sink_type}' for ref '{ref}'.") from exc
 
-        sink = sink_cls(
-            sink_reference=ref,
-            resource_location=location,
-            iosink_method_kwargs=kwargs.get("iosink_method_kwargs", kwargs),
-        )
+        if sink_cls is BufferSink:
+            if buffer_store is None or session_id is None:
+                raise ValueError(f"Buffer sink '{ref}' requires runtime buffer_store and session_id.")
+            sink = sink_cls(
+                sink_reference=ref,
+                resource_location=str(spec["location"]),
+                iosink_method_kwargs=kwargs.get("iosink_method_kwargs", kwargs),
+                buffer_store=buffer_store,
+                session_id=str(session_id),
+            )
+        else:
+            sink = sink_cls(
+                sink_reference=ref,
+                resource_location=location,
+                iosink_method_kwargs=kwargs.get("iosink_method_kwargs", kwargs),
+            )
         sinks.register_sink(sink)
 
     return sinks

--- a/src/modacor/modules/__init__.py
+++ b/src/modacor/modules/__init__.py
@@ -18,6 +18,7 @@ from modacor.modules.base_modules.append_source import AppendSource
 from modacor.modules.base_modules.bitwise_or_masks import BitwiseOrMasks
 from modacor.modules.base_modules.combine_uncertainties import CombineUncertainties
 from modacor.modules.base_modules.combine_uncertainties_max import CombineUncertaintiesMax
+from modacor.modules.base_modules.copy_databundle_keys import CopyDataBundleKeys
 from modacor.modules.base_modules.divide import Divide
 from modacor.modules.base_modules.find_scale_factor1d import FindScaleFactor1D
 from modacor.modules.base_modules.multiply import Multiply
@@ -44,6 +45,7 @@ __all__ = [
     "BitwiseOrMasks",
     "CombineUncertainties",
     "CombineUncertaintiesMax",
+    "CopyDataBundleKeys",
     "Divide",
     "IndexPixels",
     "IndexedAverager",

--- a/src/modacor/modules/base_modules/append_processing_data.py
+++ b/src/modacor/modules/base_modules/append_processing_data.py
@@ -43,16 +43,17 @@ class AppendProcessingData(ProcessStep):
        - ``units_location`` via :meth:`IoSources.get_static_metadata`, or
        - ``units_override`` as a direct units string, or
        - defaults to dimensionless if neither is provided.
-    3. Optionally loads uncertainty arrays from ``uncertainties_sources``.
-    4. Wraps everything in a :class:`BaseData` instance.
-    5. Sets ``BaseData.rank_of_data`` based on the configured ``rank_of_data``:
+    3. Optionally loads weights from ``weights_location``.
+    4. Optionally loads uncertainty arrays from ``uncertainties_sources``.
+    5. Wraps everything in a :class:`BaseData` instance.
+    6. Sets ``BaseData.rank_of_data`` based on the configured ``rank_of_data``:
        - If it is an ``int``, it is used directly.
        - If it is a ``str``, it is interpreted as an IoSources metadata reference
          (``'<io_source_id>::<dataset_path>'``) and read via
          :meth:`IoSources.get_static_metadata`, then converted to ``int``.
        - Validation and bounds checking are handled by :func:`validate_rank_of_data`
          inside :class:`BaseData`.
-    6. Stores the resulting :class:`BaseData` under the configured
+    7. Stores the resulting :class:`BaseData` under the configured
        ``databundle_output_key`` (default: ``"signal"``) in a
        :class:`DataBundle` at ``self.processing_data[processing_key]``. If that
        DataBundle already exists, it is updated: existing entries are preserved
@@ -101,6 +102,11 @@ class AppendProcessingData(ProcessStep):
                 "type": (str, type(None)),
                 "default": None,
                 "doc": "Optional unit string that overrides loaded units.",
+            },
+            "weights_location": {
+                "type": (str, type(None)),
+                "default": None,
+                "doc": "Optional IoSources reference for BaseData weights.",
             },
             "uncertainties_sources": {
                 "type": dict,
@@ -180,6 +186,7 @@ class AppendProcessingData(ProcessStep):
             - databundle_output_key (str)
             - units_location (str | None)
             - units_override (str | None)
+            - weights_location (str | None)
             - uncertainties_sources (dict[str, str])
         """
         cfg = self.configuration
@@ -209,6 +216,10 @@ class AppendProcessingData(ProcessStep):
         if units_override is not None and not isinstance(units_override, str):
             raise TypeError("'units_override' must be a units string if provided.")
 
+        weights_location = cfg.get("weights_location")
+        if weights_location is not None and not isinstance(weights_location, str):
+            raise TypeError("'weights_location' must be a string '<source_ref>::<dataset_path>' or None.")
+
         uncertainties_sources: dict[str, str] = cfg.get("uncertainties_sources", {}) or {}
         if not isinstance(uncertainties_sources, dict):
             raise TypeError(
@@ -222,6 +233,7 @@ class AppendProcessingData(ProcessStep):
             "databundle_output_key": databundle_output_key,
             "units_location": units_location,
             "units_override": units_override,
+            "weights_location": weights_location,
             "uncertainties_sources": uncertainties_sources,
         }
 
@@ -275,6 +287,7 @@ class AppendProcessingData(ProcessStep):
         databundle_output_key: str = cfg["databundle_output_key"]
         units_location = cfg["units_location"]
         units_override = cfg["units_override"]
+        weights_location = cfg["weights_location"]
         uncertainties_sources: dict[str, str] = cfg["uncertainties_sources"]
 
         io_sources: IoSources = self.io_sources
@@ -292,6 +305,7 @@ class AppendProcessingData(ProcessStep):
             signal_source=signal_location,
             units_source=units_location,
             uncertainty_sources=uncertainties_sources,
+            weights_source=weights_location,
         )
 
         # Override units if requested

--- a/src/modacor/modules/base_modules/copy_databundle_keys.py
+++ b/src/modacor/modules/base_modules/copy_databundle_keys.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+__coding__ = "utf-8"
+__authors__ = ["Brian R. Pauw"]
+__copyright__ = "Copyright 2026, The MoDaCor team"
+__date__ = "25/05/2026"
+__status__ = "Development"
+
+__all__ = ["CopyDataBundleKeys"]
+__version__ = "20260525.1"
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.process_step import ProcessStep
+from modacor.dataclasses.process_step_describer import ProcessStepDescriber
+
+
+class CopyDataBundleKeys(ProcessStep):
+    """
+    Copy selected entries from one DataBundle to another.
+
+    ``with_processing_keys`` contains two keys: target first, source second.
+    This keeps static data in a separate branch while allowing a later step to
+    attach selected static entries to a dynamic sample bundle.
+    """
+
+    documentation = ProcessStepDescriber(
+        calling_name="Copy DataBundle keys",
+        calling_id="CopyDataBundleKeys",
+        calling_module_path=Path(__file__),
+        calling_version=__version__,
+        required_data_keys=[],
+        modifies={},
+        arguments={
+            "with_processing_keys": {
+                "type": list,
+                "required": True,
+                "default": None,
+                "doc": "Two processing keys: target then source.",
+            },
+            "data_keys": {
+                "type": (list, str, type(None)),
+                "default": None,
+                "doc": "Source keys to copy to the target DataBundle under the same names.",
+            },
+            "key_map": {
+                "type": (dict, type(None)),
+                "default": None,
+                "doc": "Mapping of source key to target key. Mutually exclusive with data_keys.",
+            },
+            "copy": {
+                "type": bool,
+                "default": True,
+                "doc": "Deep-copy copied values. If False, attach the same objects by reference.",
+            },
+            "copy_axes": {
+                "type": bool,
+                "default": True,
+                "doc": "Pass with_axes to BaseData.copy when copy is True.",
+            },
+        },
+        step_keywords=["copy", "databundle", "static"],
+        step_doc="Copy selected BaseData entries between DataBundles.",
+        step_reference="",
+        step_note=(
+            "Use this to attach static maps such as Q, Psi, Omega, pixel_index, or masks "
+            "to each sample without recomputing the static branch."
+        ),
+    )
+
+    def _key_pairs(self) -> list[tuple[str, str]]:
+        data_keys = self.configuration.get("data_keys", None)
+        key_map = self.configuration.get("key_map", None)
+
+        if data_keys is not None and key_map is not None:
+            raise ValueError("CopyDataBundleKeys accepts either data_keys or key_map, not both.")
+
+        if key_map is not None:
+            if not isinstance(key_map, dict) or not key_map:
+                raise ValueError("CopyDataBundleKeys key_map must be a non-empty mapping.")
+            return [(str(source_key), str(target_key)) for source_key, target_key in key_map.items()]
+
+        if isinstance(data_keys, str):
+            keys = [data_keys]
+        elif data_keys is None:
+            raise ValueError("CopyDataBundleKeys requires data_keys or key_map.")
+        else:
+            try:
+                keys = list(data_keys)
+            except TypeError as exc:
+                raise TypeError("CopyDataBundleKeys data_keys must be a string or iterable of strings.") from exc
+
+        if not keys:
+            raise ValueError("CopyDataBundleKeys data_keys must not be empty.")
+        return [(str(key), str(key)) for key in keys]
+
+    def _copy_value(self, value: Any) -> Any:
+        if not bool(self.configuration.get("copy", True)):
+            return value
+
+        if hasattr(value, "copy"):
+            try:
+                return value.copy(with_axes=bool(self.configuration.get("copy_axes", True)))
+            except TypeError:
+                return value.copy()
+
+        return deepcopy(value)
+
+    def calculate(self) -> dict[str, DataBundle]:
+        keys = self._normalised_processing_keys()
+        assert len(keys) == 2, (
+            "CopyDataBundleKeys requires exactly two processing keys in 'with_processing_keys': "
+            "the first is the target, the second is the source."
+        )
+
+        target_processing_key, source_processing_key = keys
+        source = self.processing_data.get(source_processing_key)
+        if source is None:
+            raise KeyError(f"CopyDataBundleKeys source DataBundle not found: {source_processing_key!r}")
+
+        target = self.processing_data.get(target_processing_key)
+        if target is None:
+            target = DataBundle()
+
+        for source_key, target_key in self._key_pairs():
+            if source_key not in source:
+                raise KeyError(f"CopyDataBundleKeys source key not found: {source_processing_key}.{source_key}")
+            target[target_key] = self._copy_value(source[source_key])
+
+        return {target_processing_key: target}

--- a/src/modacor/runner/__init__.py
+++ b/src/modacor/runner/__init__.py
@@ -1,5 +1,5 @@
 """Runner helpers for loading and executing MoDaCor pipelines."""
 
-from .pipeline_runner import RunResult, run_pipeline_job
+from .pipeline_runner import PipelineRunError, RunResult, run_pipeline_job
 
-__all__ = ["RunResult", "run_pipeline_job"]
+__all__ = ["PipelineRunError", "RunResult", "run_pipeline_job"]

--- a/src/modacor/runner/pipeline_runner.py
+++ b/src/modacor/runner/pipeline_runner.py
@@ -15,7 +15,7 @@ from modacor.io.io_sinks import IoSinks
 from modacor.io.io_sources import IoSources
 from modacor.runner.pipeline import Pipeline
 
-__all__ = ["RunResult", "run_pipeline_job"]
+__all__ = ["PipelineRunError", "RunResult", "run_pipeline_job"]
 
 
 @dataclass(slots=True)
@@ -28,6 +28,23 @@ class RunResult:
     step_durations: dict[str, float]
     executed_steps: list[str]
     stopped_after_step: str | None
+
+
+class PipelineRunError(RuntimeError):
+    """Raised when a pipeline run fails after collecting partial run context."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        result: RunResult,
+        original_exception: Exception,
+        failed_step_id: str | None,
+    ) -> None:
+        super().__init__(message)
+        self.result = result
+        self.original_exception = original_exception
+        self.failed_step_id = failed_step_id
 
 
 def _ensure_pipeline(pipeline: Pipeline | Path | str) -> Pipeline:
@@ -47,6 +64,7 @@ def run_pipeline_job(
     tracer_kwargs: dict[str, Any] | None = None,
     stop_after: str | None = None,
     selected_step_ids: set[str] | list[str] | tuple[str, ...] | None = None,
+    capture_partial_on_error: bool = False,
 ) -> RunResult:
     """
     Execute a pipeline end-to-end.
@@ -76,42 +94,62 @@ def run_pipeline_job(
     step_durations: dict[str, float] = {}
     executed_steps: list[str] = []
     stopped_after_step: str | None = None
+    current_step_id: str | None = None
 
-    while pipeline_obj.is_active():
-        should_stop = False
-        for node in pipeline_obj.get_ready():
-            node.processing_data = processing_data_obj
-            node.io_sources = sources_obj
-            node.io_sinks = sinks_obj
+    try:
+        while pipeline_obj.is_active():
+            should_stop = False
+            for node in pipeline_obj.get_ready():
+                node.processing_data = processing_data_obj
+                node.io_sources = sources_obj
+                node.io_sinks = sinks_obj
 
-            step_id = str(node.step_id)
-            if selected_steps is None or step_id in selected_steps:
-                t0 = perf_counter()
-                node.execute(processing_data_obj)
-                duration = perf_counter() - t0
+                step_id = str(node.step_id)
+                current_step_id = step_id
+                if selected_steps is None or step_id in selected_steps:
+                    t0 = perf_counter()
+                    node.execute(processing_data_obj)
+                    duration = perf_counter() - t0
 
-                step_durations[step_id] = duration
-                executed_steps.append(step_id)
+                    step_durations[step_id] = duration
+                    executed_steps.append(step_id)
 
-                if tracer is not None:
-                    tracer.after_step(node, processing_data_obj, duration_s=duration)
-                    pipeline_obj.attach_tracer_event(
-                        node,
-                        tracer,
-                        include_rendered_trace=True,
-                        include_rendered_config=True,
-                        rendered_format="text/html",
-                    )
+                    if tracer is not None:
+                        tracer.after_step(node, processing_data_obj, duration_s=duration)
+                        pipeline_obj.attach_tracer_event(
+                            node,
+                            tracer,
+                            include_rendered_trace=True,
+                            include_rendered_config=True,
+                            rendered_format="text/html",
+                        )
 
-            pipeline_obj.done(node)
+                pipeline_obj.done(node)
 
-            if stop_token is not None and step_id == stop_token:
-                stopped_after_step = step_id
-                should_stop = True
+                if stop_token is not None and step_id == stop_token:
+                    stopped_after_step = step_id
+                    should_stop = True
+                    break
+
+            if should_stop:
                 break
-
-        if should_stop:
-            break
+    except Exception as exc:
+        if not capture_partial_on_error:
+            raise
+        partial_result = RunResult(
+            processing_data=processing_data_obj,
+            pipeline=pipeline_obj,
+            tracer=tracer,
+            step_durations=step_durations,
+            executed_steps=executed_steps,
+            stopped_after_step=stopped_after_step,
+        )
+        raise PipelineRunError(
+            str(exc),
+            result=partial_result,
+            original_exception=exc,
+            failed_step_id=current_step_id,
+        ) from exc
 
     return RunResult(
         processing_data=processing_data_obj,

--- a/src/modacor/server/api.py
+++ b/src/modacor/server/api.py
@@ -23,7 +23,7 @@ def create_app(  # noqa: C901
     dependencies in non-server environments.
     """
     try:
-        from fastapi import FastAPI, HTTPException, WebSocket
+        from fastapi import Body, FastAPI, HTTPException, Response, WebSocket
     except ImportError as exc:  # pragma: no cover - runtime-only dependency
         raise RuntimeError(
             "FastAPI is not installed. Install server extras, e.g. 'pip install modacor[server]'."
@@ -101,6 +101,59 @@ def create_app(  # noqa: C901
     @app.delete("/v1/sessions/{session_id}/sinks/{ref}", status_code=204)
     def delete_sink(session_id: str, ref: str) -> None:
         _call(service.delete_sink, session_id, ref)
+
+    @app.put("/v1/sessions/{session_id}/buffers/sources/{source_ref}/arrays/{data_key:path}")
+    def put_buffer_source_array(
+        session_id: str,
+        source_ref: str,
+        data_key: str,
+        payload: bytes = Body(...),
+    ) -> dict[str, Any]:
+        return _call(service.put_buffer_source_array, session_id, source_ref, data_key, payload)
+
+    @app.put("/v1/sessions/{session_id}/buffers/sources/{source_ref}/attrs/{data_key:path}")
+    def put_buffer_source_attrs(
+        session_id: str,
+        source_ref: str,
+        data_key: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return _call(service.put_buffer_source_attrs, session_id, source_ref, data_key, payload)
+
+    @app.put("/v1/sessions/{session_id}/buffers/sources/{source_ref}/metadata/{data_key:path}")
+    def put_buffer_source_metadata(
+        session_id: str,
+        source_ref: str,
+        data_key: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        return _call(service.put_buffer_source_metadata, session_id, source_ref, data_key, payload)
+
+    @app.get("/v1/sessions/{session_id}/buffers/sinks/{sink_ref}/arrays/{data_key:path}")
+    def get_buffer_sink_array(session_id: str, sink_ref: str, data_key: str) -> Response:
+        payload = _call(service.get_buffer_sink_array, session_id, sink_ref, data_key)
+        return Response(content=payload, media_type="application/x-npy")
+
+    @app.get("/v1/sessions/{session_id}/buffers/{kind}/{ref}/manifest")
+    def get_buffer_manifest(session_id: str, kind: str, ref: str) -> dict[str, Any]:
+        return _call(service.get_buffer_manifest, session_id, kind, ref)
+
+    @app.delete("/v1/sessions/{session_id}/buffers/sinks/{sink_ref}")
+    def clear_buffer_sink(session_id: str, sink_ref: str) -> dict[str, Any]:
+        return _call(service.clear_buffer_sink, session_id, sink_ref)
+
+    @app.delete("/v1/sessions/{session_id}/buffers/sinks/{sink_ref}/arrays/{data_key:path}")
+    def clear_buffer_sink_array(session_id: str, sink_ref: str, data_key: str) -> dict[str, Any]:
+        return _call(service.clear_buffer_sink_array, session_id, sink_ref, data_key)
+
+    @app.delete("/v1/sessions/{session_id}/buffers")
+    def clear_buffers(
+        session_id: str,
+        kind: str | None = None,
+        ref: str | None = None,
+        data_key: str | None = None,
+    ) -> dict[str, Any]:
+        return _call(service.clear_buffers, session_id, kind=kind, ref=ref, data_key=data_key)
 
     @app.post("/v1/sessions/{session_id}/process")
     def process(session_id: str, payload: dict[str, Any]) -> dict[str, Any]:

--- a/src/modacor/server/io_utils.py
+++ b/src/modacor/server/io_utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from modacor.io.buffer.runtime_buffer_store import RuntimeBufferStore
 from modacor.io.io_sinks import IoSinks
 from modacor.io.io_sources import IoSources
 from modacor.io.runtime_support import build_sinks_from_specs, build_sources_from_specs, write_processing_data_hdf
@@ -66,7 +67,11 @@ def _sink_kwargs_with_runtime_metadata(
     return method_kwargs
 
 
-def build_sources_from_session(session: PipelineSession) -> IoSources:
+def build_sources_from_session(
+    session: PipelineSession,
+    *,
+    buffer_store: RuntimeBufferStore | None = None,
+) -> IoSources:
     specs: list[dict[str, Any]] = []
     for ref in sorted(session.sources.keys()):
         reg = session.sources[ref]
@@ -78,10 +83,15 @@ def build_sources_from_session(session: PipelineSession) -> IoSources:
                 "kwargs": dict(reg.get("kwargs", {}) or {}),
             }
         )
-    return build_sources_from_specs(specs)
+    return build_sources_from_specs(specs, buffer_store=buffer_store, session_id=session.session_id)
 
 
-def build_sinks_from_session(session: PipelineSession, *, pipeline: Any | None = None) -> IoSinks:
+def build_sinks_from_session(
+    session: PipelineSession,
+    *,
+    pipeline: Any | None = None,
+    buffer_store: RuntimeBufferStore | None = None,
+) -> IoSinks:
     specs: list[dict[str, Any]] = []
     for ref in sorted(session.sinks.keys()):
         reg = session.sinks[ref]
@@ -101,7 +111,7 @@ def build_sinks_from_session(session: PipelineSession, *, pipeline: Any | None =
                 "kwargs": kwargs,
             }
         )
-    return build_sinks_from_specs(specs)
+    return build_sinks_from_specs(specs, buffer_store=buffer_store, session_id=session.session_id)
 
 
 def write_hdf_output(

--- a/src/modacor/server/runtime_service.py
+++ b/src/modacor/server/runtime_service.py
@@ -12,6 +12,7 @@ from time import perf_counter
 from typing import Any
 
 from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.buffer.codec import decode_npy, encode_npy
 from modacor.io.io_sinks import IoSinks
 from modacor.io.io_sources import IoSources
 from modacor.runner import run_pipeline_job
@@ -37,6 +38,7 @@ class ProcessRequest:
     changed_keys: list[str]
     write_hdf: dict[str, Any] | None = None
     run_name: str | None = None
+    rollback_snapshot: bool = True
 
 
 @dataclass(slots=True)
@@ -323,6 +325,102 @@ class RuntimeService:
         if not existed:
             raise ApiError(status_code=404, detail=f"Sink '{ref}' not found.")
 
+    def put_buffer_source_array(
+        self,
+        session_id: str,
+        source_ref: str,
+        data_key: str,
+        payload: bytes,
+    ) -> dict[str, Any]:
+        self._require_session(session_id)
+        try:
+            array = decode_npy(payload)
+            self.manager.buffer_store.put_array(session_id, "source", source_ref, data_key, array)
+        except Exception as exc:
+            raise ApiError(status_code=422, detail=f"Invalid .npy buffer payload: {exc}") from exc
+        return {
+            "session_id": session_id,
+            "kind": "source",
+            "ref": source_ref,
+            "data_key": data_key.strip("/"),
+            "shape": list(array.shape),
+            "dtype": str(array.dtype),
+        }
+
+    def put_buffer_source_attrs(
+        self,
+        session_id: str,
+        source_ref: str,
+        data_key: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._require_session(session_id)
+        if not isinstance(payload, dict):
+            raise ApiError(status_code=422, detail="Buffer attrs payload must be an object.")
+        self.manager.buffer_store.put_attrs(session_id, "source", source_ref, data_key, payload)
+        return {
+            "session_id": session_id,
+            "kind": "source",
+            "ref": source_ref,
+            "data_key": data_key.strip("/"),
+            "attrs": dict(payload),
+        }
+
+    def put_buffer_source_metadata(
+        self,
+        session_id: str,
+        source_ref: str,
+        data_key: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        self._require_session(session_id)
+        if not isinstance(payload, dict) or "value" not in payload:
+            raise ApiError(status_code=422, detail="Buffer metadata payload must be an object containing 'value'.")
+        self.manager.buffer_store.put_metadata(session_id, "source", source_ref, data_key, payload["value"])
+        return {
+            "session_id": session_id,
+            "kind": "source",
+            "ref": source_ref,
+            "data_key": data_key.strip("/"),
+            "value": payload["value"],
+        }
+
+    def get_buffer_sink_array(self, session_id: str, sink_ref: str, data_key: str) -> bytes:
+        self._require_session(session_id)
+        try:
+            array = self.manager.buffer_store.get_array(session_id, "sink", sink_ref, data_key)
+        except KeyError as exc:
+            raise ApiError(status_code=404, detail=str(exc)) from exc
+        return encode_npy(array)
+
+    def get_buffer_manifest(self, session_id: str, kind: str, ref: str) -> dict[str, Any]:
+        self._require_session(session_id)
+        try:
+            return self.manager.buffer_store.manifest(session_id, kind, ref)
+        except ValueError as exc:
+            raise ApiError(status_code=422, detail=str(exc)) from exc
+
+    def clear_buffers(
+        self,
+        session_id: str,
+        *,
+        kind: str | None = None,
+        ref: str | None = None,
+        data_key: str | None = None,
+    ) -> dict[str, Any]:
+        self._require_session(session_id)
+        try:
+            removed = self.manager.buffer_store.clear(session_id, kind=kind, ref=ref, data_key=data_key)
+        except ValueError as exc:
+            raise ApiError(status_code=422, detail=str(exc)) from exc
+        return {"session_id": session_id, "removed": removed}
+
+    def clear_buffer_sink(self, session_id: str, sink_ref: str) -> dict[str, Any]:
+        return self.clear_buffers(session_id, kind="sink", ref=sink_ref)
+
+    def clear_buffer_sink_array(self, session_id: str, sink_ref: str, data_key: str) -> dict[str, Any]:
+        return self.clear_buffers(session_id, kind="sink", ref=sink_ref, data_key=data_key)
+
     def process(self, session_id: str, payload: dict[str, Any]) -> dict[str, Any]:
         request = self._parse_process_request(payload)
         session = self._require_session(session_id)
@@ -341,8 +439,8 @@ class RuntimeService:
         sinks: IoSinks | None = None
         try:
             pipeline = Pipeline.from_yaml(session.pipeline_yaml or "")
-            sources = build_sources_from_session(session)
-            sinks = build_sinks_from_session(session, pipeline=pipeline)
+            sources = build_sources_from_session(session, buffer_store=self.manager.buffer_store)
+            sinks = build_sinks_from_session(session, pipeline=pipeline, buffer_store=self.manager.buffer_store)
             preparation = self._prepare_process_execution(
                 session_id=session_id,
                 run_id=run_id,
@@ -508,6 +606,7 @@ class RuntimeService:
             changed_keys=changed_keys,
             write_hdf=write_hdf,
             run_name=run_name,
+            rollback_snapshot=bool(payload.get("rollback_snapshot", True)),
         )
 
     def _resolve_process_mode(self, session: PipelineSession, request: ProcessRequest) -> tuple[str, str | None]:
@@ -573,7 +672,11 @@ class RuntimeService:
                 )
             )
 
-        snapshot_before_partial = deepcopy(session.processing_data) if session.processing_data is not None else None
+        snapshot_before_partial = (
+            deepcopy(session.processing_data)
+            if request.rollback_snapshot and session.processing_data is not None
+            else None
+        )
         return ProcessPreparation(
             selected_step_ids=selected_step_ids,
             snapshot_before_partial=snapshot_before_partial,
@@ -675,6 +778,7 @@ class RuntimeService:
             "skipped_steps": skipped_steps,
             "step_durations_s": result.step_durations,
             "elapsed_s": elapsed_s,
+            "rollback_snapshot": request.rollback_snapshot,
         }
         if mode_note:
             details["note"] = mode_note

--- a/src/modacor/server/runtime_service.py
+++ b/src/modacor/server/runtime_service.py
@@ -12,12 +12,13 @@ from time import perf_counter
 from typing import Any
 
 from modacor.dataclasses.processing_data import ProcessingData
+from modacor.debug.pipeline_tracer import PlainUnicodeRenderer
 from modacor.io.buffer.codec import decode_npy, encode_npy
 from modacor.io.io_sinks import IoSinks
 from modacor.io.io_sources import IoSources
 from modacor.runner import run_pipeline_job
 from modacor.runner.pipeline import Pipeline
-from modacor.runner.pipeline_runner import RunResult
+from modacor.runner.pipeline_runner import PipelineRunError, RunResult
 
 from .errors import ApiError
 from .execution import find_dirty_step_ids
@@ -27,6 +28,8 @@ from .session_manager import PipelineSession, SessionManager
 from .source_profiles import get_source_profile, list_source_profiles
 
 __all__ = ["RuntimeService"]
+
+TRACE_REPORT_LINES = 500
 
 
 @dataclass(slots=True)
@@ -740,6 +743,7 @@ class RuntimeService:
                 "snapshot_step_ids": set(session.trace_snapshot_step_ids),
             },
             selected_step_ids=preparation.selected_step_ids,
+            capture_partial_on_error=True,
         )
         elapsed_s = perf_counter() - run_t0
         session.processing_data = result.processing_data
@@ -788,6 +792,9 @@ class RuntimeService:
             details["checkpoint_boundary_step"] = preparation.boundary_step_id
         if hdf_out_path is not None:
             details["hdf_output"] = hdf_out_path
+        trace_report = self._trace_report(result)
+        if trace_report is not None:
+            details["trace_report"] = trace_report
 
         run_meta = self.manager.mark_run_succeeded(session_id, run_id, details=details)
         return {
@@ -816,16 +823,25 @@ class RuntimeService:
         if effective_mode == "partial" and preparation.snapshot_before_partial is not None:
             session.processing_data = preparation.snapshot_before_partial
 
+        original_exception = exc.original_exception if isinstance(exc, PipelineRunError) else exc
         error_code = "PARTIAL_RUN_FAILED" if effective_mode == "partial" else "RUN_FAILED"
+        error_details: dict[str, Any] = {
+            "exception_type": type(original_exception).__name__,
+            "traceback": traceback.format_exc(),
+        }
+        if isinstance(exc, PipelineRunError):
+            if exc.failed_step_id is not None:
+                error_details["failed_step_id"] = exc.failed_step_id
+            trace_report = self._trace_report(exc.result)
+            if trace_report is not None:
+                error_details["trace_report"] = trace_report
+
         self.manager.mark_run_failed(
             session_id,
             run_id,
             code=error_code,
             message=str(exc),
-            details={
-                "exception_type": type(exc).__name__,
-                "traceback": traceback.format_exc(),
-            },
+            details=error_details,
         )
         if request.mode == "auto" and effective_mode == "partial" and sources is not None and sinks is not None:
             return self._run_auto_fallback(
@@ -878,6 +894,7 @@ class RuntimeService:
                     "snapshot_processing_data": session.trace_snapshot_processing_data,
                     "snapshot_step_ids": set(session.trace_snapshot_step_ids),
                 },
+                capture_partial_on_error=True,
             )
             fallback_elapsed = perf_counter() - fallback_t0
             session.processing_data = fallback_result.processing_data
@@ -892,23 +909,29 @@ class RuntimeService:
             fallback_topo_ids = ordered_step_ids(fallback_result.pipeline)
             fallback_executed_set = set(fallback_result.executed_steps)
             fallback_skipped = [step_id for step_id in fallback_topo_ids if step_id not in fallback_executed_set]
+            trace_report = self._trace_report(fallback_result)
+            details: dict[str, Any] = {
+                "status": "succeeded",
+                "executed_steps": fallback_result.executed_steps,
+                "num_steps": len(fallback_result.executed_steps),
+                "note": "Auto fallback succeeded after partial failure.",
+                "recovered_from_run_id": recovered_from_run_id,
+                "fallback_reason": str(fallback_reason),
+                "changed_sources": request.changed_sources,
+                "changed_keys": request.changed_keys,
+                "skipped_steps": fallback_skipped,
+                "step_durations_s": fallback_result.step_durations,
+                "elapsed_s": fallback_elapsed,
+            }
+            if trace_report is not None:
+                details["trace_report"] = trace_report
+            if hdf_out_path:
+                details["hdf_output"] = hdf_out_path
+
             done = self.manager.mark_run_succeeded(
                 session_id,
                 fallback_id,
-                details={
-                    "status": "succeeded",
-                    "executed_steps": fallback_result.executed_steps,
-                    "num_steps": len(fallback_result.executed_steps),
-                    "note": "Auto fallback succeeded after partial failure.",
-                    "recovered_from_run_id": recovered_from_run_id,
-                    "fallback_reason": str(fallback_reason),
-                    "changed_sources": request.changed_sources,
-                    "changed_keys": request.changed_keys,
-                    "skipped_steps": fallback_skipped,
-                    "step_durations_s": fallback_result.step_durations,
-                    "elapsed_s": fallback_elapsed,
-                    **({"hdf_output": hdf_out_path} if hdf_out_path else {}),
-                },
+                details=details,
             )
             return {
                 "session_id": session_id,
@@ -922,16 +945,27 @@ class RuntimeService:
                 "hdf_output": done.get("hdf_output"),
             }
         except Exception as fallback_exc:
+            original_exception = (
+                fallback_exc.original_exception if isinstance(fallback_exc, PipelineRunError) else fallback_exc
+            )
+            error_details: dict[str, Any] = {
+                "exception_type": type(original_exception).__name__,
+                "traceback": traceback.format_exc(),
+                "recovered_from_run_id": recovered_from_run_id,
+            }
+            if isinstance(fallback_exc, PipelineRunError):
+                if fallback_exc.failed_step_id is not None:
+                    error_details["failed_step_id"] = fallback_exc.failed_step_id
+                trace_report = self._trace_report(fallback_exc.result)
+                if trace_report is not None:
+                    error_details["trace_report"] = trace_report
+
             self.manager.mark_run_failed(
                 session_id,
                 fallback_id,
                 code="FULL_RUN_FAILED",
                 message=str(fallback_exc),
-                details={
-                    "exception_type": type(fallback_exc).__name__,
-                    "traceback": traceback.format_exc(),
-                    "recovered_from_run_id": recovered_from_run_id,
-                },
+                details=error_details,
             )
             raise ApiError(
                 status_code=500,
@@ -941,3 +975,11 @@ class RuntimeService:
                     "details": {"session_id": session_id, "run_id": fallback_id},
                 },
             ) from fallback_exc
+
+    def _trace_report(self, result: RunResult) -> str | None:
+        if result.tracer is None:
+            return None
+        return result.tracer.last_report(
+            TRACE_REPORT_LINES,
+            renderer=PlainUnicodeRenderer(wrap_in_markdown_codeblock=False),
+        )

--- a/src/modacor/server/session_manager.py
+++ b/src/modacor/server/session_manager.py
@@ -10,6 +10,8 @@ from threading import RLock
 from typing import Any
 from uuid import uuid4
 
+from modacor.io.buffer.runtime_buffer_store import RuntimeBufferStore
+
 __all__ = ["PipelineSession", "SessionManager"]
 
 
@@ -75,6 +77,7 @@ class SessionManager:
     def __init__(self) -> None:
         self._sessions: dict[str, PipelineSession] = {}
         self._lock = RLock()
+        self.buffer_store = RuntimeBufferStore()
 
     def list_sessions(self) -> list[PipelineSession]:
         with self._lock:
@@ -118,7 +121,10 @@ class SessionManager:
 
     def delete_session(self, session_id: str) -> bool:
         with self._lock:
-            return self._sessions.pop(session_id, None) is not None
+            deleted = self._sessions.pop(session_id, None) is not None
+            if deleted:
+                self.buffer_store.clear(session_id)
+            return deleted
 
     def upsert_sources(self, session_id: str, sources: list[dict[str, Any]]) -> PipelineSession:
         with self._lock:

--- a/tests/io/buffer/test_buffer_io.py
+++ b/tests/io/buffer/test_buffer_io.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from modacor import ureg
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.buffer import BufferSink, BufferSource, RuntimeBufferStore, decode_npy, encode_npy
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.float32,
+        np.float64,
+    ],
+)
+def test_npy_codec_preserves_shape_and_dtype(dtype):
+    source = np.arange(12, dtype=dtype).reshape(1, 3, 4)
+
+    decoded = decode_npy(encode_npy(source))
+
+    assert decoded.shape == source.shape
+    assert decoded.dtype == source.dtype
+    np.testing.assert_array_equal(decoded, source)
+
+
+def test_runtime_buffer_store_arrays_attrs_metadata_manifest_and_clear():
+    store = RuntimeBufferStore()
+    store.put_array("s1", "source", "chunk", "sample/signal/signal", np.arange(6, dtype=np.float32).reshape(2, 3))
+    store.put_array("s1", "source", "chunk", "sample/mask/signal", np.ones((2, 3), dtype=np.uint32))
+    store.put_attrs("s1", "source", "chunk", "sample/signal/signal", {"units": "counts"})
+    store.put_metadata("s1", "source", "chunk", "sample/rank", 2)
+
+    manifest = store.manifest("s1", "sources", "chunk")
+
+    assert manifest["arrays"] == ["sample/mask/signal", "sample/signal/signal"]
+    assert manifest["attrs"] == ["sample/signal/signal"]
+    assert manifest["metadata"] == ["sample/rank"]
+    assert manifest["array_details"]["sample/mask/signal"]["dtype"] == "uint32"
+    assert store.get_metadata("s1", "source", "chunk", "sample/rank") == 2
+
+    store.put_array("s1", "source", "chunk", "sample/mask/signal", np.zeros((2, 3), dtype=np.uint8))
+    assert store.get_array_dtype("s1", "source", "chunk", "sample/mask/signal") == np.dtype("uint8")
+
+    removed = store.clear("s1", kind="source", ref="chunk", data_key="sample/mask/signal")
+    assert removed == 1
+    assert not store.has_array("s1", "source", "chunk", "sample/mask/signal")
+
+    removed = store.clear("s1", kind="source", ref="chunk")
+    assert removed == 3
+    assert store.manifest("s1", "source", "chunk")["arrays"] == []
+
+
+def test_buffer_source_reads_arrays_metadata_and_attrs():
+    store = RuntimeBufferStore()
+    signal = np.arange(6, dtype=np.float32).reshape(2, 3)
+    store.put_array("s1", "source", "chunk", "sample/signal/signal", signal)
+    store.put_attrs("s1", "source", "chunk", "sample/signal/signal", {"units": "counts"})
+    store.put_metadata("s1", "source", "chunk", "sample/rank", 2)
+
+    source = BufferSource(
+        source_reference="chunk",
+        resource_location="buffer://session",
+        session_id="s1",
+        buffer_store=store,
+    )
+
+    np.testing.assert_array_equal(source.get_data("sample/signal/signal"), signal)
+    np.testing.assert_array_equal(source.get_data("sample/signal/signal", load_slice=np.s_[0]), signal[0])
+    assert source.get_data_shape("sample/signal/signal") == (2, 3)
+    assert source.get_data_dtype("sample/signal/signal") == np.dtype("float32")
+    assert source.get_static_metadata("sample/signal/signal@units") == "counts"
+    assert source.get_static_metadata("sample/rank") == 2
+    with pytest.raises(KeyError):
+        source.get_data("missing")
+
+
+def test_buffer_sink_writes_basedata_roots_and_leaf_paths():
+    store = RuntimeBufferStore()
+    processing_data = ProcessingData()
+    bundle = DataBundle()
+    bundle["signal"] = BaseData(
+        signal=np.arange(6, dtype=np.float32).reshape(2, 3),
+        units=ureg.Unit("count"),
+        uncertainties={"poisson": np.ones((2, 3), dtype=np.float32)},
+        weights=np.full((2, 3), 0.5, dtype=np.float32),
+        rank_of_data=2,
+    )
+    bundle["mask"] = BaseData(signal=np.ones((2, 3), dtype=np.int16), units=ureg.dimensionless, rank_of_data=2)
+    processing_data["sample"] = bundle
+
+    sink = BufferSink(
+        sink_reference="out",
+        resource_location="buffer://session",
+        session_id="s1",
+        buffer_store=store,
+    )
+
+    result = sink.write("current", processing_data, data_paths=["/sample/signal", "/sample/mask/signal"])
+
+    assert "current/sample/signal/signal" in result["arrays"]
+    np.testing.assert_array_equal(
+        store.get_array("s1", "sink", "out", "current/sample/signal/uncertainties/poisson"),
+        np.ones((2, 3), dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        store.get_array("s1", "sink", "out", "current/sample/mask/signal"),
+        np.ones((2, 3), dtype=np.int16),
+    )
+    attrs = store.get_attrs("s1", "sink", "out", "current/sample/signal/signal")
+    assert attrs["units"] == "count"
+    assert attrs["rank_of_data"] == 2

--- a/tests/io/test_runtime_support.py
+++ b/tests/io/test_runtime_support.py
@@ -16,10 +16,11 @@ from modacor import ureg
 from modacor.dataclasses.basedata import BaseData
 from modacor.dataclasses.databundle import DataBundle
 from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.buffer import BufferSink, BufferSource, RuntimeBufferStore
 from modacor.io.csv.csv_sink import CSVSink
 from modacor.io.hdf.hdf_processing_sink import HDFProcessingSink
 from modacor.io.io_sink import IoSink
-from modacor.io.runtime_support import build_sinks_from_specs, write_processing_data_hdf
+from modacor.io.runtime_support import build_sinks_from_specs, build_sources_from_specs, write_processing_data_hdf
 
 
 @define(kw_only=True)
@@ -68,6 +69,32 @@ def test_build_sinks_from_specs_builds_hdf_processing_sink(tmp_path: Path):
     assert isinstance(sink, HDFProcessingSink)
     assert sink.resource_location == out_file
     assert sink.iosink_method_kwargs == {"compression": "gzip"}
+
+
+def test_build_sources_and_sinks_from_specs_support_buffer_type():
+    store = RuntimeBufferStore()
+
+    sources = build_sources_from_specs(
+        [{"ref": "chunk_input", "type": "buffer", "location": "buffer://session"}],
+        buffer_store=store,
+        session_id="s1",
+    )
+    sinks = build_sinks_from_specs(
+        [{"ref": "chunk_output", "type": "buffer", "location": "buffer://session"}],
+        buffer_store=store,
+        session_id="s1",
+    )
+
+    assert isinstance(sources.get_source("chunk_input"), BufferSource)
+    assert isinstance(sinks.get_sink("chunk_output"), BufferSink)
+
+
+def test_build_buffer_specs_require_runtime_context():
+    with pytest.raises(ValueError, match="requires runtime buffer_store"):
+        build_sources_from_specs([{"ref": "chunk_input", "type": "buffer", "location": "buffer://session"}])
+
+    with pytest.raises(ValueError, match="requires runtime buffer_store"):
+        build_sinks_from_specs([{"ref": "chunk_output", "type": "buffer", "location": "buffer://session"}])
 
 
 def test_build_sinks_from_specs_supports_custom_sink(tmp_path: Path):

--- a/tests/modules/base_modules/test_append_processing_data.py
+++ b/tests/modules/base_modules/test_append_processing_data.py
@@ -75,6 +75,8 @@ def io_sources(signal_array) -> IoSources:
         data={
             "entry/instrument/detector/data": signal_array,
             "entry/instrument/detector/sigma": np.ones_like(signal_array),
+            "entry/instrument/detector/weights": np.full_like(signal_array, 0.5, dtype=float),
+            "entry/instrument/detector/mask": np.ones_like(signal_array, dtype=np.int16),
         },
         metadata={
             "config/rank": 1,
@@ -218,6 +220,63 @@ def test_append_processing_data_adds_uncertainties(io_sources, signal_array):
 
     assert "sigma" in bd.uncertainties
     np.testing.assert_array_equal(bd.uncertainties["sigma"], np.ones_like(signal_array))
+
+
+def test_append_processing_data_adds_weights(io_sources, signal_array):
+    step = _make_step(io_sources)
+
+    step.modify_config_by_dict(
+        {
+            "processing_key": "sample",
+            "signal_location": "sample::entry/instrument/detector/data",
+            "rank_of_data": 2,
+            "units_location": None,
+            "units_override": None,
+            "weights_location": "sample::entry/instrument/detector/weights",
+            "uncertainties_sources": {},
+        }
+    )
+
+    output = step.calculate()
+    bd = output["sample"]["signal"]
+
+    np.testing.assert_array_equal(bd.weights, np.full_like(signal_array, 0.5, dtype=float))
+
+
+def test_append_processing_data_loads_mask_as_separate_basedata_entry(io_sources, signal_array):
+    processing_data = ProcessingData()
+    step_signal = _make_step(io_sources, processing_data=processing_data)
+    step_mask = _make_step(io_sources, processing_data=processing_data)
+
+    step_signal.modify_config_by_dict(
+        {
+            "processing_key": "sample",
+            "signal_location": "sample::entry/instrument/detector/data",
+            "rank_of_data": 2,
+            "units_location": None,
+            "units_override": None,
+            "uncertainties_sources": {},
+        }
+    )
+    step_signal.calculate()
+
+    step_mask.modify_config_by_dict(
+        {
+            "processing_key": "sample",
+            "databundle_output_key": "mask",
+            "signal_location": "sample::entry/instrument/detector/mask",
+            "rank_of_data": 2,
+            "units_location": None,
+            "units_override": "dimensionless",
+            "uncertainties_sources": {},
+        }
+    )
+    step_mask.calculate()
+
+    bundle = processing_data["sample"]
+    assert set(bundle.keys()) == {"signal", "mask"}
+    assert bundle["mask"].signal.dtype == np.dtype("int16")
+    np.testing.assert_array_equal(bundle["mask"].signal, np.ones_like(signal_array, dtype=np.int16))
 
 
 def test_append_processing_data_rejects_legacy_pixel_unit_metadata(io_sources):

--- a/tests/modules/base_modules/test_copy_databundle_keys.py
+++ b/tests/modules/base_modules/test_copy_databundle_keys.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from modacor import ureg
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.io_sources import IoSources
+from modacor.modules.base_modules.copy_databundle_keys import CopyDataBundleKeys
+
+TEST_IO_SOURCES = IoSources()
+
+
+def _basedata(values: list[float]) -> BaseData:
+    return BaseData(signal=np.asarray(values, dtype=float), units=ureg.dimensionless)
+
+
+def _processing_data() -> ProcessingData:
+    processing_data = ProcessingData()
+    processing_data["sample"] = DataBundle(signal=_basedata([1.0, 2.0, 3.0]))
+    processing_data["static"] = DataBundle(
+        {
+            "Q": _basedata([0.1, 0.2, 0.3]),
+            "Psi": _basedata([10.0, 20.0, 30.0]),
+        }
+    )
+    return processing_data
+
+
+def test_copy_databundle_keys_copies_selected_keys() -> None:
+    processing_data = _processing_data()
+    step = CopyDataBundleKeys(io_sources=TEST_IO_SOURCES)
+    step.modify_config_by_kwargs(with_processing_keys=["sample", "static"], data_keys=["Q", "Psi"])
+
+    step(processing_data)
+
+    assert set(processing_data["sample"]) == {"signal", "Q", "Psi"}
+    np.testing.assert_allclose(processing_data["sample"]["Q"].signal, [0.1, 0.2, 0.3])
+    assert processing_data["sample"]["Q"] is not processing_data["static"]["Q"]
+    processing_data["sample"]["Q"].signal[0] = 99.0
+    assert processing_data["static"]["Q"].signal[0] == 0.1
+
+
+def test_copy_databundle_keys_can_rename_keys() -> None:
+    processing_data = _processing_data()
+    step = CopyDataBundleKeys(io_sources=TEST_IO_SOURCES)
+    step.modify_config_by_kwargs(with_processing_keys=["sample", "static"], key_map={"Q": "Q_static"})
+    step.processing_data = processing_data
+
+    output = step.calculate()
+
+    assert list(output) == ["sample"]
+    np.testing.assert_allclose(processing_data["sample"]["Q_static"].signal, [0.1, 0.2, 0.3])
+    assert "Q" not in processing_data["sample"]
+
+
+def test_copy_databundle_keys_can_attach_by_reference() -> None:
+    processing_data = _processing_data()
+    step = CopyDataBundleKeys(io_sources=TEST_IO_SOURCES)
+    step.modify_config_by_kwargs(with_processing_keys=["sample", "static"], data_keys=["Q"], copy=False)
+
+    step(processing_data)
+
+    assert processing_data["sample"]["Q"] is processing_data["static"]["Q"]
+
+
+def test_copy_databundle_keys_requires_two_processing_keys() -> None:
+    processing_data = _processing_data()
+    step = CopyDataBundleKeys(io_sources=TEST_IO_SOURCES)
+    step.modify_config_by_kwargs(with_processing_keys=["sample"], data_keys=["Q"])
+    step.processing_data = processing_data
+
+    with pytest.raises(AssertionError):
+        step.calculate()
+
+
+def test_copy_databundle_keys_requires_data_keys_or_key_map() -> None:
+    processing_data = _processing_data()
+    step = CopyDataBundleKeys(io_sources=TEST_IO_SOURCES)
+    step.modify_config_by_kwargs(with_processing_keys=["sample", "static"])
+    step.processing_data = processing_data
+
+    with pytest.raises(ValueError, match="requires data_keys or key_map"):
+        step.calculate()

--- a/tests/runner/test_pipeline_runner.py
+++ b/tests/runner/test_pipeline_runner.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from modacor import ureg
 from modacor.dataclasses.basedata import BaseData
@@ -12,7 +13,7 @@ from modacor.dataclasses.databundle import DataBundle
 from modacor.dataclasses.process_step import ProcessStep
 from modacor.dataclasses.processing_data import ProcessingData
 from modacor.runner.pipeline import Pipeline
-from modacor.runner.pipeline_runner import run_pipeline_job
+from modacor.runner.pipeline_runner import PipelineRunError, run_pipeline_job
 
 
 class SeedSignal(ProcessStep):
@@ -30,6 +31,11 @@ class AddOne(ProcessStep):
         return {"sample": out}
 
 
+class FailStep(ProcessStep):
+    def calculate(self) -> dict[str, DataBundle]:
+        raise ValueError("synthetic failure")
+
+
 def test_run_pipeline_job_executes_and_traces():
     s1 = SeedSignal(step_id="s1")
     s2 = AddOne(step_id="s2")
@@ -44,6 +50,36 @@ def test_run_pipeline_job_executes_and_traces():
     assert result.tracer is not None
     assert "s1" in result.pipeline.trace_events
     assert "s2" in result.pipeline.trace_events
+
+
+def test_run_pipeline_job_error_keeps_partial_trace_context():
+    s1 = SeedSignal(step_id="seed")
+    s2 = FailStep(step_id="fail")
+    pipeline = Pipeline.from_dict({s1: set(), s2: {s1}}, name="unit-test-fail")
+
+    with pytest.raises(PipelineRunError) as excinfo:
+        run_pipeline_job(
+            pipeline,
+            trace=True,
+            trace_watch={"sample": ["signal"]},
+            capture_partial_on_error=True,
+        )
+
+    err = excinfo.value
+    assert err.failed_step_id == "fail"
+    assert isinstance(err.original_exception, ValueError)
+    assert err.result.executed_steps == ["seed"]
+    assert err.result.tracer is not None
+    assert "seed" in err.result.tracer.last_report(10)
+
+
+def test_run_pipeline_job_raises_original_error_by_default():
+    s1 = SeedSignal(step_id="seed")
+    s2 = FailStep(step_id="fail")
+    pipeline = Pipeline.from_dict({s1: set(), s2: {s1}}, name="unit-test-fail-default")
+
+    with pytest.raises(ValueError, match="synthetic failure"):
+        run_pipeline_job(pipeline)
 
 
 def test_run_pipeline_job_can_stop_after_step():

--- a/tests/scripts/test_reshape_nexus_metadata.py
+++ b/tests/scripts/test_reshape_nexus_metadata.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import h5py
 import numpy as np
 
-SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "reshape_stacked_nexus_metadata.py"
-SPEC = importlib.util.spec_from_file_location("reshape_stacked_nexus_metadata", SCRIPT_PATH)
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "reshape_nexus_metadata.py"
+SPEC = importlib.util.spec_from_file_location("reshape_nexus_metadata", SCRIPT_PATH)
 reshape_mod = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 sys.modules[SPEC.name] = reshape_mod
@@ -32,6 +32,16 @@ def _create_stacked_file(path: Path) -> None:
 
         sample.create_dataset("sample_name", data=np.array([b"a", b"b", b"c"]))
         h5.create_dataset("entry1/pixel_map", data=np.ones((4, 5)))
+
+
+def _create_unstacked_file(path: Path) -> None:
+    with h5py.File(path, "w") as h5:
+        detector = h5.create_group("entry1/instrument/detector00")
+        detector.create_dataset("data", data=np.zeros((1, 4, 5), dtype=np.float32))
+
+        sample = h5.create_group("entry1/sample")
+        sample.create_dataset("thickness", data=np.array([1.2]))
+        sample.create_dataset("transmission", data=np.array([0.9]))
 
 
 def test_convert_file_appends_trailing_singleton_dimensions(tmp_path: Path) -> None:
@@ -113,3 +123,16 @@ def test_exclude_metadata_paths_skips_automatic_discovery(tmp_path: Path) -> Non
     with h5py.File(output, "r") as h5:
         assert h5["entry1/sample/thickness"].shape == (3, 1)
         assert h5["entry1/sample/transmission"].shape == (3, 1, 1, 1)
+
+
+def test_size_one_metadata_is_not_expanded(tmp_path: Path) -> None:
+    source = tmp_path / "source.nxs"
+    output = tmp_path / "output.nxs"
+    _create_unstacked_file(source)
+
+    plans = reshape_mod.convert_file(source, output)
+
+    assert plans == []
+    with h5py.File(output, "r") as h5:
+        assert h5["entry1/sample/thickness"].shape == (1,)
+        assert h5["entry1/sample/transmission"].shape == (1,)

--- a/tests/scripts/test_reshape_stacked_nexus_metadata.py
+++ b/tests/scripts/test_reshape_stacked_nexus_metadata.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "reshape_stacked_nexus_metadata.py"
+SPEC = importlib.util.spec_from_file_location("reshape_stacked_nexus_metadata", SCRIPT_PATH)
+reshape_mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = reshape_mod
+SPEC.loader.exec_module(reshape_mod)
+
+
+def _create_stacked_file(path: Path) -> None:
+    with h5py.File(path, "w") as h5:
+        detector = h5.create_group("entry1/instrument/detector00")
+        detector.create_dataset("data", data=np.zeros((3, 1, 4, 5), dtype=np.float32))
+        exposure = detector.create_dataset("frame_exposure_time", data=np.array([[1.0], [2.0], [3.0]]))
+        exposure.attrs["units"] = "s"
+        detector.create_dataset("averaged_number_of_frames", data=np.array([10, 11, 12], dtype=np.int64))
+
+        sample = h5.create_group("entry1/sample")
+        transmission = sample.create_dataset("transmission", data=np.array([[0.8], [0.9], [1.0]]))
+        transmission.attrs["units"] = "dimensionless"
+
+        beam = sample.create_group("beam")
+        beam.create_dataset("flux", data=np.array([[100.0], [110.0], [120.0]]), compression="gzip")
+
+        sample.create_dataset("sample_name", data=np.array([b"a", b"b", b"c"]))
+        h5.create_dataset("entry1/pixel_map", data=np.ones((4, 5)))
+
+
+def test_convert_file_appends_trailing_singleton_dimensions(tmp_path: Path) -> None:
+    source = tmp_path / "source.nxs"
+    output = tmp_path / "output.nxs"
+    _create_stacked_file(source)
+
+    plans = reshape_mod.convert_file(source, output)
+
+    assert {plan.path for plan in plans} == {
+        "entry1/instrument/detector00/averaged_number_of_frames",
+        "entry1/instrument/detector00/frame_exposure_time",
+        "entry1/sample/beam/flux",
+        "entry1/sample/transmission",
+    }
+
+    with h5py.File(output, "r") as h5:
+        assert h5["entry1/instrument/detector00/data"].shape == (3, 1, 4, 5)
+        assert h5["entry1/instrument/detector00/frame_exposure_time"].shape == (3, 1, 1, 1)
+        assert h5["entry1/instrument/detector00/averaged_number_of_frames"].shape == (3, 1, 1, 1)
+        assert h5["entry1/sample/transmission"].shape == (3, 1, 1, 1)
+        assert h5["entry1/sample/beam/flux"].shape == (3, 1, 1, 1)
+        assert h5["entry1/sample/beam/flux"].compression == "gzip"
+        assert h5["entry1/sample/transmission"].attrs["units"] == "dimensionless"
+        assert h5["entry1/sample/sample_name"].shape == (3,)
+        assert h5["entry1/pixel_map"].shape == (4, 5)
+
+        np.testing.assert_allclose(
+            h5["entry1/sample/transmission"][()],
+            np.array([0.8, 0.9, 1.0]).reshape((3, 1, 1, 1)),
+        )
+
+
+def test_dry_run_does_not_write_output_file(tmp_path: Path) -> None:
+    source = tmp_path / "source.nxs"
+    output = tmp_path / "output.nxs"
+    _create_stacked_file(source)
+
+    plans = reshape_mod.convert_file(source, output, dry_run=True)
+
+    assert plans
+    assert not output.exists()
+    with h5py.File(source, "r") as h5:
+        assert h5["entry1/sample/transmission"].shape == (3, 1)
+
+
+def test_metadata_paths_can_restrict_conversion(tmp_path: Path) -> None:
+    source = tmp_path / "source.nxs"
+    output = tmp_path / "output.nxs"
+    _create_stacked_file(source)
+
+    plans = reshape_mod.convert_file(
+        source,
+        output,
+        metadata_paths=["entry1/sample/transmission", "/entry1/sample/beam/flux"],
+    )
+
+    assert [plan.path for plan in plans] == ["entry1/sample/transmission", "entry1/sample/beam/flux"]
+    with h5py.File(output, "r") as h5:
+        assert h5["entry1/sample/transmission"].shape == (3, 1, 1, 1)
+        assert h5["entry1/sample/beam/flux"].shape == (3, 1, 1, 1)
+        assert h5["entry1/instrument/detector00/frame_exposure_time"].shape == (3, 1)

--- a/tests/scripts/test_reshape_stacked_nexus_metadata.py
+++ b/tests/scripts/test_reshape_stacked_nexus_metadata.py
@@ -94,3 +94,22 @@ def test_metadata_paths_can_restrict_conversion(tmp_path: Path) -> None:
         assert h5["entry1/sample/transmission"].shape == (3, 1, 1, 1)
         assert h5["entry1/sample/beam/flux"].shape == (3, 1, 1, 1)
         assert h5["entry1/instrument/detector00/frame_exposure_time"].shape == (3, 1)
+
+
+def test_exclude_metadata_paths_skips_automatic_discovery(tmp_path: Path) -> None:
+    source = tmp_path / "source.nxs"
+    output = tmp_path / "output.nxs"
+    _create_stacked_file(source)
+    with h5py.File(source, "a") as h5:
+        h5["entry1/sample"].create_dataset("thickness", data=np.array([[1.0], [1.1], [1.2]]))
+
+    plans = reshape_mod.convert_file(
+        source,
+        output,
+        exclude_metadata_paths=["/entry1/sample/thickness"],
+    )
+
+    assert "entry1/sample/thickness" not in {plan.path for plan in plans}
+    with h5py.File(output, "r") as h5:
+        assert h5["entry1/sample/thickness"].shape == (3, 1)
+        assert h5["entry1/sample/transmission"].shape == (3, 1, 1, 1)

--- a/tests/server/test_api_e2e.py
+++ b/tests/server/test_api_e2e.py
@@ -14,6 +14,7 @@ from modacor import ureg
 from modacor.dataclasses.basedata import BaseData
 from modacor.dataclasses.databundle import DataBundle
 from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.buffer import decode_npy, encode_npy
 from modacor.runner.pipeline import Pipeline
 from modacor.runner.pipeline_runner import RunResult
 from modacor.server.api import create_app
@@ -27,6 +28,12 @@ TestClient = testclient_mod.TestClient
 def _post_json(client: TestClient, url: str, payload: dict):
     response = client.post(url, json=payload)
     assert response.status_code in {200, 201, 202}, response.text
+    return response.json()
+
+
+def _put_npy(client: TestClient, url: str, array: np.ndarray):
+    response = client.put(url, content=encode_npy(array), headers={"content-type": "application/x-npy"})
+    assert response.status_code == 200, response.text
     return response.json()
 
 
@@ -184,6 +191,63 @@ steps:
     assert "step_durations_s" in run_meta
     assert "elapsed_s" in run_meta
     assert "dirty_steps" in run_meta
+
+
+def test_api_process_rollback_snapshot_flag_controls_partial_snapshot(monkeypatch):
+    manager = SessionManager()
+    app = create_app(session_manager=manager)
+    client = TestClient(app)
+
+    pipeline_yaml = """
+name: rollback_flag
+steps:
+  p:
+    module: PoissonUncertainties
+    requires_steps: []
+    configuration:
+      with_processing_keys:
+        - sample
+"""
+    for session_id, rollback_snapshot in (("sess-rollback-on", True), ("sess-rollback-off", False)):
+        _post_json(
+            client,
+            "/v1/sessions",
+            {
+                "session_id": session_id,
+                "pipeline": {"yaml_text": pipeline_yaml},
+            },
+        )
+        session = manager.get_session(session_id)
+        processing_data = ProcessingData()
+        bundle = DataBundle()
+        bundle["signal"] = BaseData(signal=np.array([1.0, 2.0]), units=ureg.Unit("count"))
+        processing_data["sample"] = bundle
+        session.processing_data = processing_data
+
+    calls = {"count": 0}
+
+    def fake_deepcopy(value):
+        calls["count"] += 1
+        return value
+
+    monkeypatch.setattr("modacor.server.runtime_service.deepcopy", fake_deepcopy)
+
+    _post_json(
+        client,
+        "/v1/sessions/sess-rollback-on/process",
+        {"mode": "partial", "changed_keys": ["sample.signal"]},
+    )
+    _post_json(
+        client,
+        "/v1/sessions/sess-rollback-off/process",
+        {"mode": "partial", "changed_keys": ["sample.signal"], "rollback_snapshot": False},
+    )
+
+    assert calls["count"] == 1
+    on_meta = manager.get_session("sess-rollback-on").run_history[-1]
+    off_meta = manager.get_session("sess-rollback-off").run_history[-1]
+    assert on_meta["rollback_snapshot"] is True
+    assert off_meta["rollback_snapshot"] is False
 
 
 def test_api_sources_patch_upserts_single_source():
@@ -417,6 +481,122 @@ steps:
     lines = out_file.read_text(encoding="utf-8").splitlines()
     assert lines[0] == "sample/Q/signal,sample/signal/signal"
     assert len(lines) == 7
+
+
+def test_api_buffer_source_sink_processes_keyed_chunk_data():
+    manager = SessionManager()
+    app = create_app(session_manager=manager)
+    client = TestClient(app)
+
+    pipeline_yaml = """
+name: api_buffer_chunk
+steps:
+  load_signal:
+    module: AppendProcessingData
+    requires_steps: []
+    configuration:
+      processing_key: sample
+      databundle_output_key: signal
+      signal_location: "chunk_input::sample/signal/signal"
+      units_location: "chunk_input::sample/signal/signal@units"
+      weights_location: "chunk_input::sample/signal/weights"
+      uncertainties_sources:
+        poisson: "chunk_input::sample/signal/uncertainties/poisson"
+      rank_of_data: 2
+  load_mask:
+    module: AppendProcessingData
+    requires_steps: []
+    configuration:
+      processing_key: sample
+      databundle_output_key: mask
+      signal_location: "chunk_input::sample/mask/signal"
+      units_override: dimensionless
+      rank_of_data: 2
+  export:
+    module: SinkProcessingData
+    requires_steps:
+      - load_signal
+      - load_mask
+    configuration:
+      target: "chunk_output::current"
+      data_paths:
+        - /sample/signal
+        - /sample/mask
+"""
+    _post_json(
+        client,
+        "/v1/sessions",
+        {
+            "session_id": "sess-buffer",
+            "pipeline": {"yaml_text": pipeline_yaml},
+        },
+    )
+    _post_json(
+        client,
+        "/v1/sessions/sess-buffer/sources/patch",
+        {"ref": "chunk_input", "type": "buffer", "location": "buffer://session"},
+    )
+    _post_json(
+        client,
+        "/v1/sessions/sess-buffer/sinks/patch",
+        {"ref": "chunk_output", "type": "buffer", "location": "buffer://session"},
+    )
+
+    signal = np.arange(12, dtype=np.float32).reshape(1, 3, 4)
+    weights = np.full(signal.shape, 0.25, dtype=np.float32)
+    poisson = np.ones(signal.shape, dtype=np.float32)
+    mask = np.zeros(signal.shape, dtype=np.int16)
+    mask[:, 1, 2] = -1
+
+    _put_npy(client, "/v1/sessions/sess-buffer/buffers/sources/chunk_input/arrays/sample/signal/signal", signal)
+    _put_npy(client, "/v1/sessions/sess-buffer/buffers/sources/chunk_input/arrays/sample/signal/weights", weights)
+    _put_npy(
+        client,
+        "/v1/sessions/sess-buffer/buffers/sources/chunk_input/arrays/sample/signal/uncertainties/poisson",
+        poisson,
+    )
+    _put_npy(client, "/v1/sessions/sess-buffer/buffers/sources/chunk_input/arrays/sample/mask/signal", mask)
+
+    attrs_response = client.put(
+        "/v1/sessions/sess-buffer/buffers/sources/chunk_input/attrs/sample/signal/signal",
+        json={"units": "count"},
+    )
+    assert attrs_response.status_code == 200, attrs_response.text
+
+    result = _post_json(
+        client,
+        "/v1/sessions/sess-buffer/process",
+        {"mode": "full", "rollback_snapshot": False},
+    )
+    assert result["status"] == "succeeded"
+
+    signal_response = client.get(
+        "/v1/sessions/sess-buffer/buffers/sinks/chunk_output/arrays/current/sample/signal/signal"
+    )
+    assert signal_response.status_code == 200, signal_response.text
+    roundtrip_signal = decode_npy(signal_response.content)
+    assert roundtrip_signal.dtype == np.dtype("float32")
+    np.testing.assert_array_equal(roundtrip_signal, signal)
+
+    mask_response = client.get("/v1/sessions/sess-buffer/buffers/sinks/chunk_output/arrays/current/sample/mask/signal")
+    assert mask_response.status_code == 200, mask_response.text
+    roundtrip_mask = decode_npy(mask_response.content)
+    assert roundtrip_mask.dtype == np.dtype("int16")
+    np.testing.assert_array_equal(roundtrip_mask, mask)
+
+    manifest = client.get("/v1/sessions/sess-buffer/buffers/sinks/chunk_output/manifest")
+    assert manifest.status_code == 200, manifest.text
+    assert "current/sample/signal/uncertainties/poisson" in manifest.json()["arrays"]
+
+    clear_one = client.delete("/v1/sessions/sess-buffer/buffers/sinks/chunk_output/arrays/current/sample/mask/signal")
+    assert clear_one.status_code == 200, clear_one.text
+    assert clear_one.json()["removed"] >= 1
+    missing_mask = client.get("/v1/sessions/sess-buffer/buffers/sinks/chunk_output/arrays/current/sample/mask/signal")
+    assert missing_mask.status_code == 404
+
+    clear_sink = client.delete("/v1/sessions/sess-buffer/buffers/sinks/chunk_output")
+    assert clear_sink.status_code == 200, clear_sink.text
+    assert clear_sink.json()["removed"] >= 1
 
 
 def test_api_source_templates_and_profile_validation():

--- a/tests/server/test_api_e2e.py
+++ b/tests/server/test_api_e2e.py
@@ -16,7 +16,7 @@ from modacor.dataclasses.databundle import DataBundle
 from modacor.dataclasses.processing_data import ProcessingData
 from modacor.io.buffer import decode_npy, encode_npy
 from modacor.runner.pipeline import Pipeline
-from modacor.runner.pipeline_runner import RunResult
+from modacor.runner.pipeline_runner import PipelineRunError, RunResult
 from modacor.server.api import create_app
 from modacor.server.session_manager import SessionManager
 
@@ -369,6 +369,95 @@ def test_api_process_passes_configured_sinks_to_runner(monkeypatch, tmp_path: Pa
 
     assert result["status"] == "succeeded"
     assert captured["sinks"].get_sink("export_csv").resource_location == tmp_path / "out.csv"
+
+
+def test_api_process_stores_trace_report_in_run_metadata(monkeypatch):
+    manager = SessionManager()
+    app = create_app(session_manager=manager)
+    client = TestClient(app)
+
+    _post_json(
+        client,
+        "/v1/sessions",
+        {
+            "session_id": "sess-trace-report",
+            "pipeline": {"yaml_text": "name: trace_report\nsteps: {}\n"},
+            "trace": {"enabled": True},
+        },
+    )
+    captured = {}
+
+    class FakeTracer:
+        def last_report(self, n: int, *, renderer=None) -> str:
+            captured["n"] = n
+            captured["renderer"] = type(renderer).__name__
+            return "trace report\nshape: [1065, 1030]"
+
+    def fake_run_pipeline_job(pipeline, **kwargs):  # noqa: ARG001
+        return RunResult(
+            processing_data=ProcessingData(),
+            pipeline=pipeline,
+            tracer=FakeTracer(),
+            step_durations={},
+            executed_steps=[],
+            stopped_after_step=None,
+        )
+
+    monkeypatch.setattr("modacor.server.runtime_service.run_pipeline_job", fake_run_pipeline_job)
+
+    result = _post_json(client, "/v1/sessions/sess-trace-report/process", {"mode": "full"})
+    runs = client.get("/v1/sessions/sess-trace-report/runs")
+
+    assert result["status"] == "succeeded"
+    assert runs.status_code == 200
+    assert runs.json()["runs"][-1]["trace_report"] == "trace report\nshape: [1065, 1030]"
+    assert captured == {"n": 500, "renderer": "PlainUnicodeRenderer"}
+
+
+def test_api_process_failure_stores_partial_trace_report(monkeypatch):
+    manager = SessionManager()
+    app = create_app(session_manager=manager)
+    client = TestClient(app)
+
+    _post_json(
+        client,
+        "/v1/sessions",
+        {
+            "session_id": "sess-failed-trace-report",
+            "pipeline": {"yaml_text": "name: failed_trace_report\nsteps: {}\n"},
+            "trace": {"enabled": True},
+        },
+    )
+
+    class FakeTracer:
+        def last_report(self, n: int, *, renderer=None) -> str:  # noqa: ARG002
+            return "partial trace report\nshape: [1, 1065, 1030]"
+
+    def fake_run_pipeline_job(pipeline, **kwargs):  # noqa: ARG001
+        partial_result = RunResult(
+            processing_data=ProcessingData(),
+            pipeline=pipeline,
+            tracer=FakeTracer(),
+            step_durations={},
+            executed_steps=["PD_sample"],
+            stopped_after_step=None,
+        )
+        raise PipelineRunError(
+            "synthetic failure",
+            result=partial_result,
+            original_exception=ValueError("synthetic failure"),
+            failed_step_id="FA",
+        )
+
+    monkeypatch.setattr("modacor.server.runtime_service.run_pipeline_job", fake_run_pipeline_job)
+
+    response = client.post("/v1/sessions/sess-failed-trace-report/process", json={"mode": "full"})
+    latest_error = client.get("/v1/sessions/sess-failed-trace-report/errors/latest").json()
+
+    assert response.status_code == 500
+    details = latest_error["latest_error"]["details"]
+    assert details["failed_step_id"] == "FA"
+    assert details["trace_report"] == "partial trace report\nshape: [1, 1065, 1030]"
 
 
 def test_api_process_write_hdf_closes_file_for_immediate_reopen(monkeypatch, tmp_path: Path):

--- a/tests/server/test_io_utils.py
+++ b/tests/server/test_io_utils.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from modacor.io.buffer import BufferSink, BufferSource
 from modacor.io.hdf.hdf_processing_sink import HDFProcessingSink
 from modacor.runner.pipeline import Pipeline
-from modacor.server.io_utils import build_sinks_from_session
+from modacor.server.io_utils import build_sinks_from_session, build_sources_from_session
 from modacor.server.session_manager import SessionManager
 
 
@@ -45,3 +46,22 @@ def test_build_sinks_from_session_can_opt_into_hdf_runtime_metadata(tmp_path: Pa
     assert sink.iosink_method_kwargs["pipeline_yaml"] == pipeline_yaml
     assert sink.iosink_method_kwargs["pipeline_spec"]["name"] == "metadata-demo"
     assert "trace_events" not in sink.iosink_method_kwargs
+
+
+def test_build_sources_and_sinks_from_session_support_buffer_type():
+    manager = SessionManager()
+    session = manager.create_session(session_id="s-buffer", pipeline_yaml="name: buffer-demo\nsteps: {}\n")
+    manager.upsert_sources(
+        "s-buffer",
+        [{"ref": "chunk_input", "type": "buffer", "location": "buffer://session"}],
+    )
+    manager.upsert_sinks(
+        "s-buffer",
+        [{"ref": "chunk_output", "type": "buffer", "location": "buffer://session"}],
+    )
+
+    sources = build_sources_from_session(session, buffer_store=manager.buffer_store)
+    sinks = build_sinks_from_session(session, buffer_store=manager.buffer_store)
+
+    assert isinstance(sources.get_source("chunk_input"), BufferSource)
+    assert isinstance(sinks.get_sink("chunk_output"), BufferSink)

--- a/tests/server/test_session_manager.py
+++ b/tests/server/test_session_manager.py
@@ -63,3 +63,12 @@ def test_session_manager_sink_lifecycle_does_not_disturb_sources():
     assert manager.delete_sink("s3", "export_csv") is False
     assert "sample" in session.sources
     assert session.sinks == {}
+
+
+def test_session_manager_delete_clears_buffer_store():
+    manager = SessionManager()
+    manager.create_session(session_id="s-buffer", pipeline_yaml="name: p\nsteps: {}\n")
+    manager.buffer_store.put_array("s-buffer", "source", "chunk", "data", [1, 2, 3])
+
+    assert manager.delete_session("s-buffer") is True
+    assert manager.buffer_store.manifest("s-buffer", "source", "chunk")["arrays"] == []


### PR DESCRIPTION
Adding tools to improve server-based operation. Main additions include the option to have a buffer IoSource, which can be filled with a numpy array using the web API. That will allow the processing of frames in quick succession, when used in combination with an IoSource with the static (meta)data. Other tools include a module to copy BaseData between ProcessingData (e.g. useful when copying precomputed masks, Q or Psi arrays to the sample databundle). Default is to copy the reference, which is quick, but a deep copy can also be made. 

Time to process a MOUSE operando measurement now is under 300 ms in a single-threaded server session. 