### PR TITLE
Add ProcessSteps for masking

### DIFF
--- a/src/modacor/modules/__init__.py
+++ b/src/modacor/modules/__init__.py
@@ -15,6 +15,7 @@ __status__ = "Development"  # "Development", "Production"
 from modacor.modules.base_modules.append_processing_data import AppendProcessingData
 from modacor.modules.base_modules.append_sink import AppendSink
 from modacor.modules.base_modules.append_source import AppendSource
+from modacor.modules.base_modules.apply_mask import ApplyMask
 from modacor.modules.base_modules.bitwise_or_masks import BitwiseOrMasks
 from modacor.modules.base_modules.combine_uncertainties import CombineUncertainties
 from modacor.modules.base_modules.combine_uncertainties_max import CombineUncertaintiesMax
@@ -28,6 +29,7 @@ from modacor.modules.base_modules.reduce_dimensionality import ReduceDimensional
 from modacor.modules.base_modules.sink_processing_data import SinkProcessingData
 from modacor.modules.base_modules.subtract import Subtract
 from modacor.modules.base_modules.subtract_databundles import SubtractDatabundles
+from modacor.modules.base_modules.threshold_mask import ThresholdMask
 from modacor.modules.base_modules.units_label_update import UnitsLabelUpdate
 from modacor.modules.technique_modules.scattering.index_pixels import IndexPixels
 from modacor.modules.technique_modules.scattering.indexed_averager import IndexedAverager
@@ -42,6 +44,7 @@ __all__ = [
     "AppendProcessingData",
     "AppendSink",
     "AppendSource",
+    "ApplyMask",
     "BitwiseOrMasks",
     "CombineUncertainties",
     "CombineUncertaintiesMax",
@@ -59,6 +62,7 @@ __all__ = [
     "SolidAngleCorrection",
     "SubtractDatabundles",
     "Subtract",
+    "ThresholdMask",
     "UnitsLabelUpdate",
     "XSGeometry",
     "XSGeometryFromPixelCoordinates",

--- a/src/modacor/modules/base_modules/apply_mask.py
+++ b/src/modacor/modules/base_modules/apply_mask.py
@@ -105,7 +105,7 @@ class ApplyMask(ProcessStep):
         # Canonicalize target to uint32 once (needed for NeXus-style 32-bit bitfields)
         if mask.dtype != np.uint32:
             mask = mask.astype(np.uint32, copy=True)  # one-time allocation
-            target_bd.signal = tgt
+            mask_bd.signal = mask
 
         for sk in source_keys:
             src_bd: BaseData = bundle[sk]

--- a/src/modacor/modules/base_modules/apply_mask.py
+++ b/src/modacor/modules/base_modules/apply_mask.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+__coding__ = "utf-8"
+__authors__ = [
+    "Brian R. Pauw",
+    "Anja F. Hörmann",
+]  # add names to the list as appropriate
+__copyright__ = "Copyright 2026, The MoDaCor team"
+__date__ = "16/07/2026"
+__status__ = "Development"  # "Development", "Production"
+# end of header and standard imports
+
+__all__ = ["ApplyMask"]
+__version__ = "20260716.1"
+
+from pathlib import Path
+
+import numpy as np
+
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.process_step import ProcessStep
+from modacor.dataclasses.process_step_describer import ProcessStepDescriber
+
+
+class ApplyMask(ProcessStep):
+    """
+    Mask the data using the 'mask' BaseData entry. Data is set to zero where the mask is 1.
+
+    MoDaCor's Masks are 32-bit integer bitfields (NeXus convention). This step updates the
+    signal in-place by masking invalid pixels according to the mask.
+    """
+
+    documentation = ProcessStepDescriber(
+        calling_name="Apply mask to the signal in a DataBundle",
+        calling_id="ApplyMask",
+        calling_module_path=Path(__file__),
+        calling_version=__version__,
+        required_data_keys=["mask", "signal"],
+        modifies={"signal": ["signal"]},
+        arguments={
+            "with_processing_keys": {
+                "type": list,
+                "required": True,
+                "default": ["sample"],
+                "doc": "Single processing key identifying the DataBundle to update.",
+            },
+            "mask_key": {
+                "type": str,
+                "default": "mask",
+                "doc": "BaseData key for the mask to be used inside the DataBundle.",
+            },
+            "basedata_to_mask": {
+                "type": list,
+                "required": True,
+                "default": ["signal"],
+                "doc": "List of BaseData keys to apply the mask to.",
+            },
+        },
+        step_keywords=["mask", "signal", "apply", "databundle"],
+        step_doc="Combine multiple mask arrays stored as different BaseData keys in the same DataBundle.",
+        step_reference="NeXus mask bit-field convention (NXdata/NXdetector masks)",
+        step_note="""
+            Configuration:
+              with_processing_keys: [sample]     # required, single databundle key
+              mask_key: mask                     # optional, default: mask
+              basedata_to_mask: [signal, ...]    # optional, default: [signal]
+
+            Performs:
+              basedata[mask] = 0  (in-place, for each source)
+        """,
+    )
+
+    @staticmethod
+    def _require_int(arr: np.ndarray, name: str) -> None:
+        assert np.issubdtype(arr.dtype, np.integer), (
+            f"{name} must be an integer mask, got {arr.dtype}."
+        )
+
+    def calculate(self) -> dict[str, DataBundle]:
+        cfg = self.configuration
+
+        keys = self._normalised_processing_keys()
+        assert len(keys) == 1, (
+            "BitwiseOrMasks requires a single databundle processing key."
+        )
+        processing_key = keys[0]
+        mask_key = cfg.get("mask_key", "mask")
+        source_keys = cfg.get("basedata_to_mask", ["signal"])
+
+        assert isinstance(source_keys, list) and source_keys, (
+            "basedata_to_mask must be a non-empty list."
+        )
+
+        bundle = self.processing_data[processing_key]
+        mask_bd: BaseData = bundle[mask_key]
+        mask = mask_bd.signal
+
+        self._require_int(mask, f"{processing_key}::{mask_key}")  # noqa: E231
+
+        # Canonicalize target to uint32 once (needed for NeXus-style 32-bit bitfields)
+        if mask.dtype != np.uint32:
+            mask = mask.astype(np.uint32, copy=True)  # one-time allocation
+            target_bd.signal = tgt
+
+        for sk in source_keys:
+            src_bd: BaseData = bundle[sk]
+            src = src_bd.signal
+
+            src[mask == 1] = 0
+
+        return {processing_key: bundle}

--- a/src/modacor/modules/base_modules/threshold_mask.py
+++ b/src/modacor/modules/base_modules/threshold_mask.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+__coding__ = "utf-8"
+__authors__ = [
+    "Brian R. Pauw",
+    "Anja F. Hörmann",
+]  # add names to the list as appropriate
+__copyright__ = "Copyright 2026, The MoDaCor team"
+__date__ = "17/07/2026"
+__status__ = "Development"  # "Development", "Production"
+# end of header and standard imports
+
+__all__ = ["ThresholdMask"]
+__version__ = "20260717.1"
+
+from pathlib import Path
+
+import numpy as np
+
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.process_step import ProcessStep
+from modacor.dataclasses.process_step_describer import ProcessStepDescriber
+from modacor.modules.helpers import attach_prepared_data
+
+
+class ThresholdMask(ProcessStep):
+    """
+    Create a mask based on a threshold, where values of 'signal' above the threshold are
+    masked. This can be used to mask detector panel gaps marked by a large integer and
+    hot pixels.
+
+    MoDaCor's Masks are 32-bit integer bitfields (NeXus convention). This step creates a
+    new mask at the specified target_mask_key (default: threshold_mask).
+    """
+
+    documentation = ProcessStepDescriber(
+        calling_name="Mask signal above a threshold",
+        calling_id="ThresholdMask",
+        calling_module_path=Path(__file__),
+        calling_version=__version__,
+        required_data_keys=["signal"],
+        modifies={},
+        arguments={
+            "with_processing_keys": {
+                "type": list,
+                "required": True,
+                "default": ["sample"],
+                "doc": "Single processing key identifying the DataBundle to update.",
+            },
+            "target_mask_key": {
+                "type": str,
+                "default": "threshold_mask",
+                "doc": "BaseData key for the mask to create inside the DataBundle.",
+            },
+            "threshold": {
+                "type": float,
+                "default": 1.0e9,
+                "doc": "Threshold above which the data shall be masked.",
+            },
+        },
+        step_keywords=["mask", "threshold", "databundle"],
+        step_doc="Create a mask that masks values in 'signal' above a given threshold.",
+        step_reference="",
+        step_note="""
+            Configuration:
+              with_processing_keys: [sample]     # required, single databundle key
+              target_mask_key: threshold_mask    # optional, default: threshold_mask
+              threshold: 1e9                     # optional, default: 1e9
+
+            Performs:
+              threshold_mask = np.where(signal > threshold, 1, 0)
+        """,
+    )
+
+    def calculate(self) -> dict[str, DataBundle]:
+        cfg = self.configuration
+
+        keys = self._normalised_processing_keys()
+        assert len(keys) == 1, (
+            "ThresholdMask requires a single databundle processing key."
+        )
+        processing_key = keys[0]
+        target_key = cfg.get("target_mask_key", "threshold_mask")
+        threshold = float(cfg.get("threshold", 1.0e9))
+
+        assert isinstance(threshold, float), (
+            "threshold must be a floating-point number."
+        )
+
+        bundle = self.processing_data[processing_key]
+        signal_bd: BaseData = bundle["signal"]
+        signal = signal_bd.signal
+
+        # signal may have more than 2 dimensions but mask should be of rank 2
+        while signal.ndim > 2:
+            signal = np.mean(signal, axis=0)
+
+        mask = np.where(signal > threshold, 1, 0)
+        # Convert only if needed (uint8/int16/etc -> uint32)
+        mask_u32 = (
+            mask if mask.dtype == np.uint32 else mask.astype(np.uint32, copy=False)
+        )
+
+        mask_bd = BaseData(signal=mask_u32, units="", rank_of_data=2)
+
+        self._prepared_data = {target_key: mask_bd}
+
+        output = attach_prepared_data(
+            self.processing_data,
+            keys,
+            self._prepared_data,
+            logger=self.logger,
+            module_name="ThresholdMask",
+        )
+
+        return output
+
+        # return {processing_key: bundle}

--- a/tests/modules/base_modules/test_apply_mask.py
+++ b/tests/modules/base_modules/test_apply_mask.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+
+__coding__ = "utf-8"
+__authors__ = ["Anja F. Hörmann"]  # add names to the list as appropriate
+__copyright__ = "Copyright 2026, The MoDaCor team"
+__date__ = "04/08/2026"
+__status__ = "Development"  # "Development", "Production"
+# end of header and standard imports
+
+import unittest
+
+import numpy as np
+
+from modacor import ureg
+from modacor.dataclasses.basedata import BaseData
+from modacor.dataclasses.databundle import DataBundle
+from modacor.dataclasses.processing_data import ProcessingData
+from modacor.io.io_sources import IoSources
+
+# module under test
+from modacor.modules.base_modules.apply_mask import ApplyMask
+
+TEST_IO_SOURCES = IoSources()
+
+class TestApplyMaskProcessingStep(unittest.TestCase):
+    """Testing class for modacor/modules/base_modules/apply_mask.py"""
+
+    def setUp(self):
+        self.test_processing_data = ProcessingData()
+
+        tgt = np.ones((2, 3), dtype=np.uint32)
+        mask = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.uint32)
+
+        db = DataBundle(
+            mask=BaseData(signal=mask, units=ureg.dimensionless, uncertainties={}),
+            signal=BaseData(signal=tgt, units=ureg.dimensionless, uncertainties={}),
+        )
+        self.test_processing_data["sample"] = db
+
+    def _make_step(self, *, mask="mask", sources=None) -> BitwiseOrMasks:
+        step = ApplyMask(io_sources=TEST_IO_SOURCES)
+        step.configuration = {
+            "with_processing_keys": ["sample"],
+            "mask_key": mask,
+            "basedata_to_mask": ["signal"],
+        }
+        step.processing_data = self.test_processing_data
+        return step
+
+    # ------------------------------------------------------------------ #
+    # Actual tests
+    # ------------------------------------------------------------------ #
+
+    def test_apply_mask_expected_signal(self):
+        "Test that the right pixels are masked on a small array"
+
+        self.setUp()
+
+        step = self._make_step()
+
+        step.processing_data = self.test_processing_data
+        step.calculate()
+        out = step.processing_data["sample"]["signal"].signal
+
+        expected = np.array([[0, 1, 1], [1, 0, 1]])
+        np.testing.assert_array_equal(out, expected)
+
+    def test_target_non_uint32_is_upcast_to_uint32_once(self):
+        """
+        If the mask isn't uint32 (e.g. int64), the step should convert it to uint32
+        (one-time allocation) and then OR into that.
+        """
+        self.test_processing_data = ProcessingData()
+
+        mask_i64 = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.int64)
+        tgt = np.ones((2, 3), dtype=np.uint32)
+
+        
+        db = DataBundle(
+            mask=BaseData(signal=mask_i64, units=ureg.dimensionless, uncertainties={}),
+            signal=BaseData(signal=tgt, units=ureg.dimensionless, uncertainties={}),
+        )
+        self.test_processing_data["sample"] = db
+
+        step = self._make_step()
+        step.processing_data = self.test_processing_data
+
+        before_id = id(self.test_processing_data["sample"]["mask"].signal)
+        step.calculate()
+
+        out = self.test_processing_data["sample"]["mask"].signal
+        self.assertEqual(out.dtype, np.uint32)
+        self.assertNotEqual(id(out), before_id)  # replacement happened due to upcast
+
+        expected = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.uint32)
+        np.testing.assert_array_equal(out, expected)

--- a/tests/modules/base_modules/test_threshold_mask.py
+++ b/tests/modules/base_modules/test_threshold_mask.py
@@ -22,7 +22,7 @@ from modacor.dataclasses.processing_data import ProcessingData
 from modacor.io.io_sources import IoSources
 
 # module under test
-from modacor.modules.base_modules.apply_mask import ApplyMask
+from modacor.modules.base_modules.threshold_mask import ThresholdMask
 
 TEST_IO_SOURCES = IoSources()
 
@@ -33,21 +33,19 @@ class TestApplyMaskProcessingStep(unittest.TestCase):
     def setUp(self):
         self.test_processing_data = ProcessingData()
 
-        tgt = np.ones((2, 3), dtype=np.uint32)
-        mask = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.uint32)
+        signal = np.array([[0,1,4e9],[2,3,7e5]], dtype=np.uint32)
 
         db = DataBundle(
-            mask=BaseData(signal=mask, units=ureg.dimensionless, uncertainties={}),
-            signal=BaseData(signal=tgt, units=ureg.dimensionless, uncertainties={}),
+            signal=BaseData(signal=signal, units=ureg.dimensionless, uncertainties={}),
         )
         self.test_processing_data["sample"] = db
 
-    def _make_step(self, *, mask="mask", sources=None) -> BitwiseOrMasks:
-        step = ApplyMask(io_sources=TEST_IO_SOURCES)
+    def _make_step(self, *, mask="threshold_mask", sources=None) -> BitwiseOrMasks:
+        step = ThresholdMask(io_sources=TEST_IO_SOURCES)
         step.configuration = {
             "with_processing_keys": ["sample"],
-            "mask_key": mask,
-            "basedata_to_mask": ["signal"],
+            "target_mask_key": mask,
+            "threshold": 1e9,
         }
         step.processing_data = self.test_processing_data
         return step
@@ -56,7 +54,7 @@ class TestApplyMaskProcessingStep(unittest.TestCase):
     # Actual tests
     # ------------------------------------------------------------------ #
 
-    def test_apply_mask_expected_signal(self):
+    def test_threshold_mask_expected_mask(self):
         "Test that the right pixels are masked on a small array"
 
         self.setUp()
@@ -65,36 +63,31 @@ class TestApplyMaskProcessingStep(unittest.TestCase):
 
         step.processing_data = self.test_processing_data
         step.calculate()
-        out = step.processing_data["sample"]["signal"].signal
+        out = step.processing_data["sample"]["threshold_mask"].signal
 
-        expected = np.array([[0, 1, 1], [1, 0, 1]])
+        expected = np.array([[0,0,1],[0,0,0]], dtype=np.uint32)
         np.testing.assert_array_equal(out, expected)
 
-    def test_target_non_uint32_is_upcast_to_uint32_once(self):
+    def test_threshold_mask_ndim_signal(self):
         """
-        If the mask isn't uint32 (e.g. int64), the step should convert it to uint32
-        (one-time allocation) and then OR into that.
+        If the signal isn't of rank 2 the step should
+        average the frames before determining the mask.
         """
         self.test_processing_data = ProcessingData()
 
-        mask_i64 = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.int64)
-        tgt = np.ones((2, 3), dtype=np.uint32)
+        signal = np.array([[[0,1,4e9],[2,3,7e5]],
+                           [[0,1,4e9],[2,3,7e5]]], dtype=np.uint32)
 
         db = DataBundle(
-            mask=BaseData(signal=mask_i64, units=ureg.dimensionless, uncertainties={}),
-            signal=BaseData(signal=tgt, units=ureg.dimensionless, uncertainties={}),
+            signal=BaseData(signal=signal, units=ureg.dimensionless, uncertainties={}),
         )
         self.test_processing_data["sample"] = db
 
         step = self._make_step()
         step.processing_data = self.test_processing_data
 
-        before_id = id(self.test_processing_data["sample"]["mask"].signal)
         step.calculate()
 
-        out = self.test_processing_data["sample"]["mask"].signal
+        out = self.test_processing_data["sample"]["threshold_mask"].signal
         self.assertEqual(out.dtype, np.uint32)
-        self.assertNotEqual(id(out), before_id)  # replacement happened due to upcast
-
-        expected = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.uint32)
-        np.testing.assert_array_equal(out, expected)
+        self.assertEqual(out.ndim, 2)

--- a/tests/modules/base_modules/test_threshold_mask.py
+++ b/tests/modules/base_modules/test_threshold_mask.py
@@ -33,7 +33,7 @@ class TestApplyMaskProcessingStep(unittest.TestCase):
     def setUp(self):
         self.test_processing_data = ProcessingData()
 
-        signal = np.array([[0,1,4e9],[2,3,7e5]], dtype=np.uint32)
+        signal = np.array([[0, 1, 4e9], [2, 3, 7e5]], dtype=np.uint32)
 
         db = DataBundle(
             signal=BaseData(signal=signal, units=ureg.dimensionless, uncertainties={}),
@@ -65,7 +65,7 @@ class TestApplyMaskProcessingStep(unittest.TestCase):
         step.calculate()
         out = step.processing_data["sample"]["threshold_mask"].signal
 
-        expected = np.array([[0,0,1],[0,0,0]], dtype=np.uint32)
+        expected = np.array([[0, 0, 1], [0, 0, 0]], dtype=np.uint32)
         np.testing.assert_array_equal(out, expected)
 
     def test_threshold_mask_ndim_signal(self):
@@ -75,8 +75,8 @@ class TestApplyMaskProcessingStep(unittest.TestCase):
         """
         self.test_processing_data = ProcessingData()
 
-        signal = np.array([[[0,1,4e9],[2,3,7e5]],
-                           [[0,1,4e9],[2,3,7e5]]], dtype=np.uint32)
+        signal = np.array([[[0, 1, 4e9], [2, 3, 7e5]],
+                           [[0, 1, 4e9], [2, 3, 7e5]]], dtype=np.uint32)
 
         db = DataBundle(
             signal=BaseData(signal=signal, units=ureg.dimensionless, uncertainties={}),

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ setenv =
     # since locale.getpreferredencoding can't be changed easily
     PYTHONUTF8=1
 deps =
-    pytest_notebook @ git+https://github.com/BAMresearch/pytest-notebook@master
+    pytest_notebook_next @ git+https://github.com/BAMresearch/pytest-notebook-next@main
     ipykernel
 extras =
     tests  # Installs [project.optional-dependencies.tests]


### PR DESCRIPTION
This PR proposes to add two ProcessSteps related to masking. 
1. `ApplyMask`: The signal and optionally other BaseData are modified in-place, setting the values where `mask = 1` to zero. 
2. `ThresholdMask`: A new mask is created based on whether the values in signal are greater than `threshold`. 

Both steps have been tested qualitatively but not formally with pytest. 